### PR TITLE
Fix authentication issues in Safari

### DIFF
--- a/templates/account/login.hbs
+++ b/templates/account/login.hbs
@@ -234,6 +234,15 @@
     <script type="module">
         import init, * as Rust from "/assets/wasm/wasm_pbkdf2.js";
 
+        // A byte order mark character can show up as a result of the conversion
+        // between Rust strings (UTF-8) and JavaScript strings (UTF-16).
+        // This function removes it if there is one.
+        function removeByteOrderMark(inputString) {
+            return (inputString.charCodeAt(0) === 0xFEFF)
+                ? inputString.substr(1)
+                : inputString;
+        }
+
         (async () => {
             await init();
             const form = document.querySelector('form.login-content');
@@ -244,7 +253,7 @@
                 event.preventDefault();
                 button.disabled = true;
                 button.value = "Loading...";
-                password.value = Rust.pbkdf2_encode(password.value, email.value, 5000);
+                password.value = removeByteOrderMark(Rust.pbkdf2_encode(password.value, email.value, 5000));
                 this.submit();
             });
         })();

--- a/templates/account/manage.hbs
+++ b/templates/account/manage.hbs
@@ -449,6 +449,15 @@
     <script type="module">
         import init, * as Rust from "/assets/wasm/wasm_pbkdf2.js";
 
+        // A byte order mark character can show up as a result of the conversion
+        // between Rust strings (UTF-8) and JavaScript strings (UTF-16).
+        // This function removes it if there is one.
+        function removeByteOrderMark(inputString) {
+            return (inputString.charCodeAt(0) === 0xFEFF)
+                ? inputString.substr(1)
+                : inputString;
+        }
+
         (async () => {
             await init();
             const form = document.querySelector('form.manage-passwd');
@@ -461,9 +470,9 @@
                 event.preventDefault();
                 button.disabled = true;
                 button.value = "Loading...";
-                password.value = Rust.pbkdf2_encode(password.value, email, 5000);   
-                new_password.value = Rust.pbkdf2_encode(new_password.value, email, 5000);
-                confirm_password.value = Rust.pbkdf2_encode(confirm_password.value, email, 5000);
+                password.value = removeByteOrderMark(Rust.pbkdf2_encode(password.value, email, 5000));
+                new_password.value = removeByteOrderMark(Rust.pbkdf2_encode(new_password.value, email, 5000));
+                confirm_password.value = removeByteOrderMark(Rust.pbkdf2_encode(confirm_password.value, email, 5000));
                 this.submit();
             });
         })();

--- a/templates/account/register.hbs
+++ b/templates/account/register.hbs
@@ -242,6 +242,15 @@
     <script type="module">
         import init, * as Rust from "/assets/wasm/wasm_pbkdf2.js";
 
+        // A byte order mark character can show up as a result of the conversion
+        // between Rust strings (UTF-8) and JavaScript strings (UTF-16).
+        // This function removes it if there is one.
+        function removeByteOrderMark(inputString) {
+            return (inputString.charCodeAt(0) === 0xFEFF)
+                ? inputString.substr(1)
+                : inputString;
+        }
+
         (async () => {
             await init();
             const form = document.querySelector('form.register-content');
@@ -253,8 +262,8 @@
                 event.preventDefault();
                 button.disabled = true;
                 button.value = "Loading...";
-                password.value = Rust.pbkdf2_encode(password.value, email.value, 5000);
-                confirm_password.value = Rust.pbkdf2_encode(confirm_password.value, email.value, 5000);
+                password.value = removeByteOrderMark(Rust.pbkdf2_encode(password.value, email.value, 5000));
+                confirm_password.value = removeByteOrderMark(Rust.pbkdf2_encode(confirm_password.value, email.value, 5000));
                 this.submit();
             });
         })();


### PR DESCRIPTION
This PR solves issues related to the conversion between Rust strings (UTF-8) and JavaScript strings (UTF-16) in the WebAssembly module boundaries.  

**Closes #10.**