### PR TITLE
Added 'git2' index management strategy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,6 +28,7 @@ dependencies = [
  "flate2 1.0.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-preview 0.3.0-alpha.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "git2 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "handlebars 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "http 0.1.19 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -270,6 +271,10 @@ dependencies = [
 name = "cc"
 version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "jobserver 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num_cpus 1.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "cexpr"
@@ -758,6 +763,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "git2"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libgit2-sys 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "openssl-probe 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "openssl-sys 0.9.52 (registry+https://github.com/rust-lang/crates.io-index)",
+ "url 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "glob"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -949,6 +968,16 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "jobserver"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "getrandom 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -992,6 +1021,19 @@ version = "0.2.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "libgit2-sys"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cc 1.0.47 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libssh2-sys 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libz-sys 1.0.25 (registry+https://github.com/rust-lang/crates.io-index)",
+ "openssl-sys 0.9.52 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pkg-config 0.3.17 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "libloading"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1005,6 +1047,30 @@ name = "libsqlite3-sys"
 version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
+ "pkg-config 0.3.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "vcpkg 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "libssh2-sys"
+version = "0.2.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cc 1.0.47 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libz-sys 1.0.25 (registry+https://github.com/rust-lang/crates.io-index)",
+ "openssl-sys 0.9.52 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pkg-config 0.3.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "vcpkg 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "libz-sys"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cc 1.0.47 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
  "pkg-config 0.3.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "vcpkg 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1292,6 +1358,23 @@ dependencies = [
 name = "opaque-debug"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "openssl-probe"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.52"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "autocfg 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cc 1.0.47 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pkg-config 0.3.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "vcpkg 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "parking_lot"
@@ -2889,6 +2972,7 @@ dependencies = [
 "checksum generic-array 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)" = "c68f0274ae0e023facc3c97b2e00f076be70e254bc851d972503b328db79b2ec"
 "checksum getopts 0.2.21 (registry+https://github.com/rust-lang/crates.io-index)" = "14dbbfd5c71d70241ecf9e6f13737f7b5ce823821063188d7e46c41d371eebd5"
 "checksum getrandom 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)" = "e7db7ca94ed4cd01190ceee0d8a8052f08a247aa1b469a7f68c6a3b71afcf407"
+"checksum git2 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "39f27186fbb5ec67ece9a56990292bc5aed3c3fc51b9b07b0b52446b1dfb4a82"
 "checksum glob 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
 "checksum h2 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)" = "a5b34c246847f938a410a03c5458c7fee2274436675e76d8b903c08efc29c462"
 "checksum handlebars 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "91ef1ac30f2eaaa2b835fce73c57091cb6b9fc62b7eef285efbf980b0f20001b"
@@ -2908,14 +2992,18 @@ dependencies = [
 "checksum indexmap 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "712d7b3ea5827fcb9d4fda14bf4da5f136f0db2ae9c8f4bd4e2d1c6fde4e6db2"
 "checksum iovec 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "b2b3ea6ff95e175473f8ffe6a7eb7c00d054240321b84c57051175fe3c1e075e"
 "checksum itoa 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "501266b7edd0174f8530248f87f99c88fbe60ca4ef3dd486835b8d8d53136f7f"
+"checksum jobserver 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)" = "f2b1d42ef453b30b7387e113da1c83ab1605d90c5b4e0eb8e96d016ed3b8c160"
 "checksum js-sys 0.3.31 (registry+https://github.com/rust-lang/crates.io-index)" = "d8657b7ca06a6044ece477f6900bf7670f8b5fd0cce177a1d7094eef51e0adf4"
 "checksum juliex 0.3.0-alpha.8 (registry+https://github.com/rust-lang/crates.io-index)" = "22dcfd5923ddd3e945884e66c89f92e7ce370e8fcabc593f6af1ce76e21099bc"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
 "checksum lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 "checksum lazycell 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b294d6fa9ee409a054354afc4352b0b9ef7ca222c69b8812cbea9e7d2bf3783f"
 "checksum libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)" = "1a31a0627fdf1f6a39ec0dd577e101440b7db22672c0901fe00a9a6fbb5c24e8"
+"checksum libgit2-sys 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a30f8637eb59616ee3b8a00f6adff781ee4ddd8343a615b8238de756060cc1b3"
 "checksum libloading 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f2b111a074963af1d37a139918ac6d49ad1d0d5e47f72fd55388619691a7d753"
 "checksum libsqlite3-sys 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5e5b95e89c330291768dc840238db7f9e204fd208511ab6319b56193a7f2ae25"
+"checksum libssh2-sys 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)" = "5fcd5a428a31cbbfe059812d74f4b6cd3b9b7426c2bdaec56993c5365da1c328"
+"checksum libz-sys 1.0.25 (registry+https://github.com/rust-lang/crates.io-index)" = "2eb5e43362e38e2bca2fd5f5134c4d4564a23a5c28e9b95411652021a8675ebe"
 "checksum line-wrap 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f30344350a2a51da54c1d53be93fade8a237e545dbcc4bdbe635413f2117cab9"
 "checksum linked-hash-map 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "ae91b68aebc4ddb91978b11a1b02ddd8602a05ec19002801c5666000e05e0f83"
 "checksum lock_api 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f8912e782533a93a167888781b836336a6ca5da6175c05944c86cf28c31104dc"
@@ -2949,6 +3037,8 @@ dependencies = [
 "checksum onig 5.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e4e723fc996fff1aeab8f62205f3e8528bf498bdd5eadb2784d2d31f30077947"
 "checksum onig_sys 69.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "0a8d4efbf5f59cece01f539305191485b651acb3785b9d5eef05749f0496514e"
 "checksum opaque-debug 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2839e79665f131bdb5782e51f2c6c9599c133c6098982a54c794358bf432529c"
+"checksum openssl-probe 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "77af24da69f9d9341038eba93a073b1fdaaa1b788221b00a69bce9e762cb32de"
+"checksum openssl-sys 0.9.52 (registry+https://github.com/rust-lang/crates.io-index)" = "c977d08e1312e2f7e4b86f9ebaa0ed3b19d1daff75fae88bbb88108afbd801fc"
 "checksum parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f842b1982eb6c2fe34036a4fbfb06dd185a3f5c8edfaacdf7d1ea10b07de6252"
 "checksum parking_lot_core 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "b876b1b9e7ac6e1a74a6da34d25c42e17e8862aa409cbbbdcfc8d86c6f3bc62b"
 "checksum path-absolutize 1.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "265d16267b3791ec932b0295e9b1dad29c5315ceb5edd4f48f3f0456ba01877f"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,6 +62,9 @@ time = { version = "0.1.42", optional = true }
 num-format = { version = "0.4.0", optional = true }
 bigdecimal = { version = "0.1.0", features = ["serde"], optional = true }
 
+# git2
+git2 = { version = "0.10.1", optional = true }
+
 # logs
 log = { version = "0.3.6" }
 slog = { version = "2.5.2" }

--- a/docs/src/whats-available/index-management-strategies.md
+++ b/docs/src/whats-available/index-management-strategies.md
@@ -20,7 +20,7 @@ path = "crate-index"  # required: path of the index's local clone.
 The local clone must be present and up-to-date before launching Alexandrie.  
 Today, Alexandrie won't pull or clone on its own on startup.
 
-<!-- 'git2': using the `libgit2` library
+'git2': using the `libgit2` library
 -----------------------------------
 
 This index management strategy uses `libgit2` to manage a local clone of the index's repository.
@@ -38,4 +38,4 @@ path = "crate-index"  # required: path of the index's local clone.
 
 **NOTE:**  
 The local clone must be present and up-to-date before launching Alexandrie.  
-Today, Alexandrie won't pull or clone on its own on startup. -->
+Today, Alexandrie won't pull or clone on its own on startup.

--- a/docs/src/whats-available/mod.md
+++ b/docs/src/whats-available/mod.md
@@ -4,11 +4,13 @@ What's available ?
 Currently, not many options are implemented yet.
 
 As index management strategies, we have:
+
 - `cli`: local index clone, managed by invocations of the `git` shell command.
-- **(PLANNED)** `git2`: just like `cli`, but uses `libgit2` instead of relying on the `git` shell command.
+- `git2`: just like `cli`, but uses `libgit2` instead of relying on the `git` shell command.
 - **(PLANNED)** `remote`: remote index clone, managed by a companion server.
 
 As crate storage strategies, we have:
+
 - `disk`: local on-disk crate storage.
 - **(PLANNED)** `remote`: just like `disk`, but on a remote machine, managed by a companion server.
 - **(PLANNED)** `s3`: stores crates in an AWS S3 bucket.

--- a/src/config/index/git2.rs
+++ b/src/config/index/git2.rs
@@ -1,0 +1,24 @@
+use std::path::PathBuf;
+
+use serde::{Deserialize, Serialize};
+
+use crate::index::git2::Git2Index;
+
+/// The configuration struct for the 'git2' index management strategy.
+///
+/// ```toml
+/// [index]
+/// type = "git2"        # required
+/// path = "crate-index" # required
+/// ```
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Git2IndexConfig {
+    /// The path to the local index repository.
+    pub path: PathBuf,
+}
+
+impl From<Git2IndexConfig> for Git2Index {
+    fn from(config: Git2IndexConfig) -> Git2Index {
+        Git2Index::new(config.path).expect("could not initialize the 'git2' index")
+    }
+}

--- a/src/config/index/mod.rs
+++ b/src/config/index/mod.rs
@@ -3,8 +3,15 @@ use serde::{Deserialize, Serialize};
 /// The 'command-line' configuration.
 pub mod cli;
 
+/// The 'git2' configuration.
+#[cfg(feature = "git2")]
+pub mod git2;
+
 use crate::config::index::cli::CommandLineIndexConfig;
 use crate::index::Index;
+
+#[cfg(feature = "git2")]
+use crate::config::index::git2::Git2IndexConfig;
 
 /// The configuration enum for index management strategies.
 ///
@@ -17,12 +24,18 @@ use crate::index::Index;
 pub enum IndexConfig {
     /// The 'command-line' index management strategy (uses "git" shell command).
     CommandLine(CommandLineIndexConfig),
+    /// The 'git2' index management strategy (uses [**`libgit2`**][libgit2]).
+    /// [libgit2]: https://libgit2.org
+    #[cfg(feature = "git2")]
+    Git2(Git2IndexConfig),
 }
 
 impl From<IndexConfig> for Index {
     fn from(config: IndexConfig) -> Index {
         match config {
             IndexConfig::CommandLine(config) => Index::CommandLine(config.into()),
+            #[cfg(feature = "git2")]
+            IndexConfig::Git2(config) => Index::Git2(config.into()),
         }
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -215,6 +215,7 @@ impl TryInto<AlexError> for Error {
     }
 }
 
+#[cfg(feature = "git2")]
 impl TryInto<Git2Error> for Error {
     type Error = ();
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -36,16 +36,16 @@ pub enum Error {
     #[error("SQL error: {0}")]
     SQLError(#[source] SQLError),
     /// Version parsing errors (invalid version format parsed, etc...).
-    #[error("Semver error: {0}")]
+    #[error("semver error: {0}")]
     SemverError(#[source] SemverError),
     /// Hexadecimal decoding errors (odd length, etc...).
-    #[error("Hex error: {0}")]
+    #[error("hex error: {0}")]
     HexError(#[source] HexError),
     /// Alexandrie's custom errors (crate not found, invalid token, etc...).
-    #[error("Alexandrie error: {0}")]
+    #[error("alexandrie error: {0}")]
     AlexError(#[source] AlexError),
     /// Git2 error.
-    #[error("Git2 error: {0}")]
+    #[error("libgit2 error: {0}")]
     #[cfg(feature = "git2")]
     Git2Error(#[source] Git2Error),
 }

--- a/src/index/git2.rs
+++ b/src/index/git2.rs
@@ -1,0 +1,211 @@
+use std::fs;
+use std::io::{self, BufRead, Write};
+use std::path::{Path, PathBuf};
+use std::sync::Mutex;
+
+use semver::{Version, VersionReq};
+
+use crate::error::{AlexError, Error};
+use crate::index::{CrateVersion, Indexer};
+
+/// The 'git2' crate index management strategy type.
+///
+/// It manages the crate index using the [**`libgit2`**][libgit2] library.
+///
+/// [libgit2]: https://libgit2.org
+pub struct Git2Index {
+    /// The path of the crate index.
+    pub(crate) repo: Mutex<git2::Repository>,
+}
+
+impl Git2Index {
+    /// Create a Git2Index instance with the given path.
+    pub fn new<P: AsRef<Path>>(path: P) -> Result<Git2Index, Error> {
+        let repo = git2::Repository::open(path)?;
+        let repo = Mutex::new(repo);
+        Ok(Git2Index { repo })
+    }
+
+    fn compute_record_path(&self, name: &str) -> PathBuf {
+        let repo = self.repo.lock().unwrap();
+        let path = repo.path().parent().unwrap();
+        match name.len() {
+            1 => path.join("1").join(&name),
+            2 => path.join("2").join(&name),
+            3 => path.join("3").join(&name[..1]).join(&name),
+            _ => path.join(&name[0..2]).join(&name[2..4]).join(&name),
+        }
+    }
+}
+
+impl Indexer for Git2Index {
+    fn url(&self) -> Result<String, Error> {
+        let repo = self.repo.lock().unwrap();
+        let remote = repo.find_remote("origin")?;
+        Ok(remote.url().map_or_else(String::default, String::from))
+    }
+
+    fn refresh(&self) -> Result<(), Error> {
+        return unimplemented!();
+
+        let repo = self.repo.lock().unwrap();
+        let mut remote = repo.find_remote("origin")?;
+        let mut opts = git2::FetchOptions::new();
+        let mut callbacks = git2::RemoteCallbacks::new();
+        // TODO: configure RemoteCallbacks properly.
+        opts.remote_callbacks(callbacks);
+        remote.fetch(&["master"], Some(&mut opts), None)?;
+
+        let ours = {
+            let head = repo.head()?;
+            head.peel_to_commit()?
+        };
+        let theirs = {
+            let fetch_head = repo.find_reference("FETCH_HEAD")?;
+            fetch_head.peel_to_commit()?
+        };
+
+        let mut opts = git2::MergeOptions::new();
+        opts.fail_on_conflict(true);
+        
+        let mut index = repo.merge_commits(&ours, &theirs, Some(&opts))?;
+
+        index.write()?;
+
+        Ok(())
+    }
+
+    fn commit_and_push(&self, msg: &str) -> Result<(), Error> {
+        let repo = self.repo.lock().unwrap();
+        let oid = {
+            let mut index = repo.index()?;
+            index.add_all(&["."], git2::IndexAddOption::DEFAULT, None)?;
+            index.write_tree()?
+        };
+        let signature = repo.signature()?;
+        let tree = repo.find_tree(oid)?;
+        let parent = {
+            let head = repo.head()?;
+            head.peel_to_commit()?
+        };
+
+        repo.commit(Some("HEAD"), &signature, &signature, msg, &tree, &[&parent])?;
+
+        let mut remote = repo.find_remote("origin")?;
+        remote.push(&[], None)?;
+
+        Ok(())
+    }
+
+    fn match_record(&self, name: &str, req: VersionReq) -> Result<CrateVersion, Error> {
+        let path = self.compute_record_path(name);
+        let file = fs::File::open(path).map_err(|err| match err.kind() {
+            io::ErrorKind::NotFound => Error::from(AlexError::CrateNotFound {
+                name: String::from(name),
+            }),
+            _ => Error::from(err),
+        })?;
+        let found = io::BufReader::new(file)
+            .lines()
+            .map(|line| Some(json::from_str(line.ok()?.as_str()).ok()?))
+            .flat_map(|ret: Option<CrateVersion>| ret.into_iter())
+            .filter(|krate| req.matches(&krate.vers))
+            .max_by(|k1, k2| k1.vers.cmp(&k2.vers));
+        Ok(found.ok_or_else(|| AlexError::CrateNotFound {
+            name: String::from(name),
+        })?)
+    }
+
+    fn all_records(&self, name: &str) -> Result<Vec<CrateVersion>, Error> {
+        let path = self.compute_record_path(name);
+        let reader = io::BufReader::new(fs::File::open(path)?);
+        reader
+            .lines()
+            .map(|line| Ok(json::from_str::<CrateVersion>(line?.as_str())?))
+            .collect()
+    }
+
+    fn latest_record(&self, name: &str) -> Result<CrateVersion, Error> {
+        let records = self.all_records(name)?;
+        Ok(records
+            .into_iter()
+            .max_by(|k1, k2| k1.vers.cmp(&k2.vers))
+            .expect("at least one version should exist"))
+    }
+
+    fn add_record(&self, record: CrateVersion) -> Result<(), Error> {
+        let path = self.compute_record_path(record.name.as_str());
+
+        if let Ok(file) = fs::File::open(&path) {
+            let reader = io::BufReader::new(file);
+            let records = reader
+                .lines()
+                .map(|line| Ok(json::from_str::<CrateVersion>(line?.as_str())?))
+                .collect::<Result<Vec<CrateVersion>, Error>>()?;
+            let latest = records
+                .into_iter()
+                .max_by(|k1, k2| k1.vers.cmp(&k2.vers))
+                .expect("at least one record should exist");
+            if record.vers <= latest.vers {
+                return Err(Error::from(AlexError::VersionTooLow {
+                    krate: record.name,
+                    hosted: latest.vers,
+                    published: record.vers,
+                }));
+            }
+        } else {
+            let parent = path.parent().unwrap();
+            fs::create_dir_all(parent)?;
+        }
+
+        let mut file = fs::OpenOptions::new()
+            .write(true)
+            .append(true)
+            .create(true)
+            .open(path)?;
+        json::to_writer(&mut file, &record)?;
+        writeln!(file)?;
+        file.flush()?;
+
+        Ok(())
+    }
+
+    fn alter_record<F>(&self, name: &str, version: Version, func: F) -> Result<(), Error>
+    where
+        F: FnOnce(&mut CrateVersion),
+    {
+        let path = self.compute_record_path(name);
+        let file = fs::File::open(path.as_path()).map_err(|err| match err.kind() {
+            io::ErrorKind::NotFound => Error::from(AlexError::CrateNotFound {
+                name: String::from(name),
+            }),
+            _ => Error::from(err),
+        })?;
+        let mut krates: Vec<CrateVersion> = {
+            let mut out = Vec::new();
+            for line in io::BufReader::new(file).lines() {
+                let krate = json::from_str(line?.as_str())?;
+                out.push(krate);
+            }
+            out
+        };
+        let found = krates
+            .iter_mut()
+            .find(|krate| krate.vers == version)
+            .ok_or_else(|| {
+                Error::from(AlexError::CrateNotFound {
+                    name: String::from(name),
+                })
+            })?;
+
+        func(found);
+
+        let lines = krates
+            .into_iter()
+            .map(|krate| json::to_string(&krate))
+            .collect::<Result<Vec<String>, _>>()?;
+        fs::write(path.as_path(), lines.join("\n") + "\n")?;
+
+        Ok(())
+    }
+}

--- a/src/index/git2.rs
+++ b/src/index/git2.rs
@@ -67,7 +67,7 @@ impl Indexer for Git2Index {
 
         let mut opts = git2::MergeOptions::new();
         opts.fail_on_conflict(true);
-        
+
         let mut index = repo.merge_commits(&ours, &theirs, Some(&opts))?;
 
         index.write()?;

--- a/src/index/git2.rs
+++ b/src/index/git2.rs
@@ -38,6 +38,46 @@ impl Git2Index {
     }
 }
 
+/// Helper to run git operations that require authentication.
+///
+/// This is inspired by [the way Cargo handles this][cargo-impl].
+///
+/// [cargo-impl]: https://github.com/rust-lang/cargo/blob/94bf4781d0bbd266abe966c6fe1512bb1725d368/src/cargo/sources/git/utils.rs#L437
+fn with_credentials<F, T>(repo: &git2::Repository, mut f: F) -> Result<T, git2::Error>
+where
+    F: FnMut(&mut git2::Credentials) -> Result<T, git2::Error>,
+{
+    let config = repo.config()?;
+
+    let mut tried_sshkey = false;
+    let mut tried_cred_helper = false;
+    let mut tried_default = false;
+
+    f(&mut |url, username, allowed| {
+        if allowed.contains(git2::CredentialType::USERNAME) {
+            return Err(git2::Error::from_str("no username specified in remote URL"));
+        }
+
+        if allowed.contains(git2::CredentialType::SSH_KEY) && !tried_sshkey {
+            tried_sshkey = true;
+            let username = username.unwrap();
+            return git2::Cred::ssh_key_from_agent(username);
+        }
+
+        if allowed.contains(git2::CredentialType::USER_PASS_PLAINTEXT) && !tried_cred_helper {
+            tried_cred_helper = true;
+            return git2::Cred::credential_helper(&config, url, username);
+        }
+
+        if allowed.contains(git2::CredentialType::DEFAULT) && !tried_default {
+            tried_default = true;
+            return git2::Cred::default();
+        }
+
+        Err(git2::Error::from_str("no authentication methods succeeded"))
+    })
+}
+
 impl Indexer for Git2Index {
     fn url(&self) -> Result<String, Error> {
         let repo = self.repo.lock().unwrap();
@@ -46,33 +86,40 @@ impl Indexer for Git2Index {
     }
 
     fn refresh(&self) -> Result<(), Error> {
-        return unimplemented!();
-
         let repo = self.repo.lock().unwrap();
         let mut remote = repo.find_remote("origin")?;
-        let mut opts = git2::FetchOptions::new();
-        let mut callbacks = git2::RemoteCallbacks::new();
-        // TODO: configure RemoteCallbacks properly.
-        opts.remote_callbacks(callbacks);
-        remote.fetch(&["master"], Some(&mut opts), None)?;
+        let branch = repo
+            .branches(Some(git2::BranchType::Local))?
+            .flatten()
+            .map(|(branch, _)| branch)
+            .find(|branch| branch.is_head())
+            .ok_or_else(|| git2::Error::from_str("detached HEAD not supported"))?;
+        let branch_name = branch.name()?.expect("branch name is invalid UTF-8");
 
-        let ours = {
-            let head = repo.head()?;
-            head.peel_to_commit()?
-        };
-        let theirs = {
-            let fetch_head = repo.find_reference("FETCH_HEAD")?;
-            fetch_head.peel_to_commit()?
-        };
+        with_credentials(&repo, |cred_callback| {
+            let mut opts = git2::FetchOptions::new();
+            let mut callbacks = git2::RemoteCallbacks::new();
+            callbacks.credentials(cred_callback);
+            opts.remote_callbacks(callbacks);
+            remote.fetch(&[branch_name], Some(&mut opts), None)?;
+            Ok(())
+        })?;
 
-        let mut opts = git2::MergeOptions::new();
-        opts.fail_on_conflict(true);
-
-        let mut index = repo.merge_commits(&ours, &theirs, Some(&opts))?;
-
-        index.write()?;
-
-        Ok(())
+        let fetch_head = repo.find_reference("FETCH_HEAD")?;
+        let fetch_commit = repo.reference_to_annotated_commit(&fetch_head)?;
+        let (analysis, _) = repo.merge_analysis(&[&fetch_commit])?;
+        if analysis.is_up_to_date() {
+            Ok(())
+        } else if analysis.is_fast_forward() {
+            let refname = format!("refs/heads/{}", branch_name);
+            let mut reference = repo.find_reference(&refname)?;
+            reference.set_target(fetch_commit.id(), "Fast-forward")?;
+            repo.set_head(&refname)?;
+            repo.checkout_head(Some(git2::build::CheckoutBuilder::default().force()))?;
+            Ok(())
+        } else {
+            Err(Error::from(git2::Error::from_str("fast-forward only!")))
+        }
     }
 
     fn commit_and_push(&self, msg: &str) -> Result<(), Error> {

--- a/src/index/mod.rs
+++ b/src/index/mod.rs
@@ -4,20 +4,29 @@ use semver::{Version, VersionReq};
 pub mod cli;
 mod models;
 
+/// Index management using [**`libgit2`**][libgit2].
+/// [libgit2]: https://libgit2.org
+#[cfg(feature = "git2")]
+pub mod git2;
+
 pub use models::*;
 
 use crate::error::Error;
 use crate::index::cli::CommandLineIndex;
 
+#[cfg(feature = "git2")]
+use crate::index::git2::Git2Index;
+
 /// The crate indexing management strategy type.
 ///
 /// It represents which index management strategy is currently used.
-#[derive(Debug, Clone, PartialEq)]
 pub enum Index {
     /// Manages the crate index through the invocation of the "git" shell command.
     CommandLine(CommandLineIndex),
-    // TODO: Add an `Indexer` implementation using `git2`.
-    // Git2(Git2Index),
+    /// Manages the crate index using [**`libgit2`**].
+    /// [libgit2]: https://libgit2.org
+    #[cfg(feature = "git2")]
+    Git2(Git2Index),
 }
 
 /// The required trait that any crate index management type must implement.
@@ -54,42 +63,49 @@ impl Indexer for Index {
     fn url(&self) -> Result<String, Error> {
         match self {
             Index::CommandLine(idx) => idx.url(),
+            Index::Git2(idx) => idx.url(),
         }
     }
 
     fn refresh(&self) -> Result<(), Error> {
         match self {
             Index::CommandLine(idx) => idx.refresh(),
+            Index::Git2(idx) => idx.refresh(),
         }
     }
 
     fn commit_and_push(&self, msg: &str) -> Result<(), Error> {
         match self {
             Index::CommandLine(idx) => idx.commit_and_push(msg),
+            Index::Git2(idx) => idx.commit_and_push(msg),
         }
     }
 
     fn all_records(&self, name: &str) -> Result<Vec<CrateVersion>, Error> {
         match self {
             Index::CommandLine(idx) => idx.all_records(name),
+            Index::Git2(idx) => idx.all_records(name),
         }
     }
 
     fn latest_record(&self, name: &str) -> Result<CrateVersion, Error> {
         match self {
             Index::CommandLine(idx) => idx.latest_record(name),
+            Index::Git2(idx) => idx.latest_record(name),
         }
     }
 
     fn match_record(&self, name: &str, req: VersionReq) -> Result<CrateVersion, Error> {
         match self {
             Index::CommandLine(idx) => idx.match_record(name, req),
+            Index::Git2(idx) => idx.match_record(name, req),
         }
     }
 
     fn add_record(&self, record: CrateVersion) -> Result<(), Error> {
         match self {
             Index::CommandLine(idx) => idx.add_record(record),
+            Index::Git2(idx) => idx.add_record(record),
         }
     }
 
@@ -99,18 +115,21 @@ impl Indexer for Index {
     {
         match self {
             Index::CommandLine(idx) => idx.alter_record(name, version, func),
+            Index::Git2(idx) => idx.alter_record(name, version, func),
         }
     }
 
     fn yank_record(&self, name: &str, version: Version) -> Result<(), Error> {
         match self {
             Index::CommandLine(idx) => idx.yank_record(name, version),
+            Index::Git2(idx) => idx.yank_record(name, version),
         }
     }
 
     fn unyank_record(&self, name: &str, version: Version) -> Result<(), Error> {
         match self {
             Index::CommandLine(idx) => idx.unyank_record(name, version),
+            Index::Git2(idx) => idx.unyank_record(name, version),
         }
     }
 }

--- a/src/index/mod.rs
+++ b/src/index/mod.rs
@@ -63,6 +63,7 @@ impl Indexer for Index {
     fn url(&self) -> Result<String, Error> {
         match self {
             Index::CommandLine(idx) => idx.url(),
+            #[cfg(feature = "git2")]
             Index::Git2(idx) => idx.url(),
         }
     }
@@ -70,6 +71,7 @@ impl Indexer for Index {
     fn refresh(&self) -> Result<(), Error> {
         match self {
             Index::CommandLine(idx) => idx.refresh(),
+            #[cfg(feature = "git2")]
             Index::Git2(idx) => idx.refresh(),
         }
     }
@@ -77,6 +79,7 @@ impl Indexer for Index {
     fn commit_and_push(&self, msg: &str) -> Result<(), Error> {
         match self {
             Index::CommandLine(idx) => idx.commit_and_push(msg),
+            #[cfg(feature = "git2")]
             Index::Git2(idx) => idx.commit_and_push(msg),
         }
     }
@@ -84,6 +87,7 @@ impl Indexer for Index {
     fn all_records(&self, name: &str) -> Result<Vec<CrateVersion>, Error> {
         match self {
             Index::CommandLine(idx) => idx.all_records(name),
+            #[cfg(feature = "git2")]
             Index::Git2(idx) => idx.all_records(name),
         }
     }
@@ -91,6 +95,7 @@ impl Indexer for Index {
     fn latest_record(&self, name: &str) -> Result<CrateVersion, Error> {
         match self {
             Index::CommandLine(idx) => idx.latest_record(name),
+            #[cfg(feature = "git2")]
             Index::Git2(idx) => idx.latest_record(name),
         }
     }
@@ -98,6 +103,7 @@ impl Indexer for Index {
     fn match_record(&self, name: &str, req: VersionReq) -> Result<CrateVersion, Error> {
         match self {
             Index::CommandLine(idx) => idx.match_record(name, req),
+            #[cfg(feature = "git2")]
             Index::Git2(idx) => idx.match_record(name, req),
         }
     }
@@ -105,6 +111,7 @@ impl Indexer for Index {
     fn add_record(&self, record: CrateVersion) -> Result<(), Error> {
         match self {
             Index::CommandLine(idx) => idx.add_record(record),
+            #[cfg(feature = "git2")]
             Index::Git2(idx) => idx.add_record(record),
         }
     }
@@ -115,6 +122,7 @@ impl Indexer for Index {
     {
         match self {
             Index::CommandLine(idx) => idx.alter_record(name, version, func),
+            #[cfg(feature = "git2")]
             Index::Git2(idx) => idx.alter_record(name, version, func),
         }
     }
@@ -122,6 +130,7 @@ impl Indexer for Index {
     fn yank_record(&self, name: &str, version: Version) -> Result<(), Error> {
         match self {
             Index::CommandLine(idx) => idx.yank_record(name, version),
+            #[cfg(feature = "git2")]
             Index::Git2(idx) => idx.yank_record(name, version),
         }
     }
@@ -129,6 +138,7 @@ impl Indexer for Index {
     fn unyank_record(&self, name: &str, version: Version) -> Result<(), Error> {
         match self {
             Index::CommandLine(idx) => idx.unyank_record(name, version),
+            #[cfg(feature = "git2")]
             Index::Git2(idx) => idx.unyank_record(name, version),
         }
     }


### PR DESCRIPTION
**This PR depends on #18.**

This PR introduces a new strategy for managing the crate index named **`git2`**.  
This strategy makes use of the [**`libgit2`**][libgit2] library to interact with the crate index repository.  
This allows Alexandrie to operate in environments that doesn't have a **`git`** command available from the command line.  

The strategy's configuration is similar to the 'disk' one:
```toml
[index]
type = "git2"        # required
path = "crate-index" # required
```

The 'git2' strategy is only available if Alexandrie is compiled with the 'git2' feature enabled.  
The reason for this feature-gate is to reduce compilation times in case it isn't used/needed to be available.  

[libgit2]: https://libgit2.org

## Yet to do:
- [x] fully implement all `Indexer` trait methods
- [x] fully document the code (how is it implemented)
- [x] document the feature (at a high-level, how to use, etc...)