### PR TITLE
Introduce `max_conns` for DatabaseConfig

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@
 /crate-index
 /crate-storage
 .DS_Store
+.idea/
+alexandrie.db

--- a/README.md
+++ b/README.md
@@ -65,6 +65,13 @@ url = "<path-to-sqlite-file>"
 url = ":memory:" # ephemeral in-memory database, doesn't persists between restarts
 ```
 
+Optionally, specify the maximum number of threads for the database connection pool. 
+
+```toml
+connection_pool_max_size = 1
+```
+If not specified, the `diesel-rs` default [value](https://docs.diesel.rs/diesel/r2d2/struct.Builder.html#method.max_size) is used.
+
 Then, you can configure the crates' tarballs storage strategy and the crate index management strategy that you want to use.  
 Here is how to do it (these are also the defaults, you can leave them out if you want):
 

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ url = ":memory:" # ephemeral in-memory database, doesn't persists between restar
 Optionally, specify the maximum number of threads for the database connection pool. 
 
 ```toml
-connection_pool_max_size = 1
+max_conns = 1
 ```
 If not specified, the `diesel-rs` default [value](https://docs.diesel.rs/diesel/r2d2/struct.Builder.html#method.max_size) is used.
 

--- a/alexandrie.toml
+++ b/alexandrie.toml
@@ -15,7 +15,6 @@ links = [
 # url = "mysql://root:root@127.0.0.1:3306/alexandrie"
 # url = "postgresql://root:root@127.0.0.1:5432/alexandrie"
 url = "alexandrie.db"
-connection_pool_max_size = 1
 
 [index]
 type = "command-line"

--- a/alexandrie.toml
+++ b/alexandrie.toml
@@ -15,6 +15,7 @@ links = [
 # url = "mysql://root:root@127.0.0.1:3306/alexandrie"
 # url = "postgresql://root:root@127.0.0.1:5432/alexandrie"
 url = "alexandrie.db"
+connection_pool_max_size = 1
 
 [index]
 type = "command-line"

--- a/src/config.rs
+++ b/src/config.rs
@@ -55,7 +55,7 @@ pub struct DatabaseConfig {
     /// The database connection URL.
     pub url: String,
     /// Max connection pool size
-    pub connection_pool_max_size: Option<u32>,
+    pub max_conns: Option<u32>,
 }
 
 /// The syntax-highlighting themes configuration struct.

--- a/src/config.rs
+++ b/src/config.rs
@@ -54,6 +54,8 @@ pub struct FrontendConfig {
 pub struct DatabaseConfig {
     /// The database connection URL.
     pub url: String,
+    /// Max connection pool size
+    pub connection_pool_max_size: Option<u32>,
 }
 
 /// The syntax-highlighting themes configuration struct.
@@ -186,7 +188,7 @@ impl From<Config> for State {
         State {
             index: config.index,
             storage: config.storage,
-            repo: Repo::new(config.database.url.as_str()),
+            repo: Repo::new(&config.database),
             syntect: config.syntect.into(),
             #[cfg(feature = "frontend")]
             frontend: config.frontend.into(),

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -1,5 +1,6 @@
 use diesel::r2d2::{self, ConnectionManager, Pool, PooledConnection};
 use futures::compat::Compat01As03 as Compat;
+use crate::config::DatabaseConfig;
 
 /// The database models (struct representations of tables).
 pub mod models;
@@ -48,9 +49,13 @@ impl<T> Repo<T>
 where
     T: diesel::Connection + 'static,
 {
-    /// Constructs a `Repo<T>` for the given database URL (creates a connection pool).
-    pub fn new(database_url: &str) -> Self {
-        Self::from_pool_builder(database_url, r2d2::Builder::default())
+    /// Constructs a `Repo<T>` for the given database config (creates a connection pool).
+    pub fn new(database_config: &DatabaseConfig) -> Self {
+        let mut builder = r2d2::Builder::default();
+        if let Some(max_size) = database_config.connection_pool_max_size {
+            builder = builder.max_size(max_size)
+        }
+        Self::from_pool_builder(&database_config.url, builder)
     }
 
     /// Creates a `Repo<T>` with a custom connection pool builder.

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -1,6 +1,6 @@
+use crate::config::DatabaseConfig;
 use diesel::r2d2::{self, ConnectionManager, Pool, PooledConnection};
 use futures::compat::Compat01As03 as Compat;
-use crate::config::DatabaseConfig;
 
 /// The database models (struct representations of tables).
 pub mod models;

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -52,7 +52,7 @@ where
     /// Constructs a `Repo<T>` for the given database config (creates a connection pool).
     pub fn new(database_config: &DatabaseConfig) -> Self {
         let mut builder = r2d2::Builder::default();
-        if let Some(max_size) = database_config.connection_pool_max_size {
+        if let Some(max_size) = database_config.max_conns {
             builder = builder.max_size(max_size)
         }
         Self::from_pool_builder(&database_config.url, builder)


### PR DESCRIPTION
As noted in this [issue](https://github.com/Hirevo/alexandrie/issues/22), sqlite requires 1 connection open when set to "WAL" (WriteAheadLog) mode. 

`diesel-rs` defaults to a connection pool [size of 10](https://docs.diesel.rs/diesel/r2d2/struct.Builder.html#method.max_size), so this PR introduces an optional config value that can be used to set that value

**Closes #22.**