### PR TITLE
Support for crate badges

### DIFF
--- a/migrations/mysql/2019-12-28-072041_badges/down.sql
+++ b/migrations/mysql/2019-12-28-072041_badges/down.sql
@@ -1,0 +1,1 @@
+drop table crate_badges;

--- a/migrations/mysql/2019-12-28-072041_badges/up.sql
+++ b/migrations/mysql/2019-12-28-072041_badges/up.sql
@@ -1,0 +1,7 @@
+create table crate_badges (
+    id bigint not null auto_increment unique primary key,
+    crate_id bigint not null,
+    badge_type varchar(255) not null,
+    params varchar(1024) not null,
+    foreign key (crate_id) references crates(id) on update cascade on delete cascade
+);

--- a/migrations/postgres/2019-12-28-072041_badges/down.sql
+++ b/migrations/postgres/2019-12-28-072041_badges/down.sql
@@ -1,0 +1,1 @@
+drop table crate_badges;

--- a/migrations/postgres/2019-12-28-072041_badges/up.sql
+++ b/migrations/postgres/2019-12-28-072041_badges/up.sql
@@ -1,0 +1,7 @@
+create table crate_badges (
+    id bigserial primary key,
+    crate_id bigint not null,
+    badge_type varchar(255) not null,
+    params varchar(1024) not null,
+    foreign key (crate_id) references crates(id) on update cascade on delete cascade
+);

--- a/migrations/sqlite/2019-12-28-072041_badges/down.sql
+++ b/migrations/sqlite/2019-12-28-072041_badges/down.sql
@@ -1,0 +1,1 @@
+drop table crate_badges;

--- a/migrations/sqlite/2019-12-28-072041_badges/up.sql
+++ b/migrations/sqlite/2019-12-28-072041_badges/up.sql
@@ -1,0 +1,7 @@
+create table crate_badges (
+    id integer primary key,
+    crate_id bigint not null,
+    badge_type varchar(255) not null,
+    params varchar(1024) not null,
+    foreign key (crate_id) references crates(id) on update cascade on delete cascade
+);

--- a/src/api/publish.rs
+++ b/src/api/publish.rs
@@ -15,7 +15,9 @@ use serde::{Deserialize, Serialize};
 use tar::Archive;
 use tide::{Request, Response};
 
-use crate::db::models::{Crate, NewCrate, NewCrateAuthor, NewCrateCategory, NewCrateKeyword};
+use crate::db::models::{
+    Crate, NewBadge, NewCrate, NewCrateAuthor, NewCrateCategory, NewCrateKeyword,
+};
 use crate::db::schema::*;
 use crate::db::Connection;
 use crate::db::DATETIME_FORMAT;
@@ -45,6 +47,7 @@ struct CrateMeta {
     pub license: Option<String>,
     pub license_file: Option<String>,
     pub repository: Option<String>,
+    pub badges: Option<HashMap<String, HashMap<String, String>>>,
     pub links: Option<String>,
 }
 
@@ -65,7 +68,7 @@ struct CrateMetaDependency {
 fn link_keywords(
     conn: &Connection,
     crate_id: i64,
-    keywords: Option<&[String]>,
+    keywords: Option<Vec<String>>,
 ) -> Result<(), Error> {
     diesel::delete(crate_keywords::table.filter(crate_keywords::crate_id.eq(crate_id)))
         .execute(conn)?;
@@ -101,7 +104,7 @@ fn link_keywords(
             .collect();
 
         diesel::insert_into(crate_keywords::table)
-            .values(entries.as_slice())
+            .values(entries)
             .execute(conn)?;
     }
 
@@ -111,7 +114,7 @@ fn link_keywords(
 fn link_categories(
     conn: &Connection,
     crate_id: i64,
-    categories: Option<&[String]>,
+    categories: Option<Vec<String>>,
 ) -> Result<(), Error> {
     diesel::delete(crate_categories::table.filter(crate_categories::crate_id.eq(crate_id)))
         .execute(conn)?;
@@ -131,7 +134,36 @@ fn link_categories(
             .collect();
 
         diesel::insert_into(crate_categories::table)
-            .values(&entries)
+            .values(entries)
+            .execute(conn)?;
+    }
+
+    Ok(())
+}
+
+fn link_badges(
+    conn: &Connection,
+    crate_id: i64,
+    badges: Option<HashMap<String, HashMap<String, String>>>,
+) -> Result<(), Error> {
+    diesel::delete(crate_badges::table.filter(crate_badges::crate_id.eq(crate_id)))
+        .execute(conn)?;
+
+    if let Some(badges) = badges {
+        let entries = badges
+            .into_iter()
+            .flat_map(|(badge_type, params)| {
+                let params = json::to_string(&params).ok()?;
+                Some(NewBadge {
+                    crate_id,
+                    badge_type,
+                    params,
+                })
+            })
+            .collect::<Vec<_>>();
+
+        diesel::insert_into(crate_badges::table)
+            .values(entries)
             .execute(conn)?;
     }
 
@@ -150,7 +182,7 @@ pub(crate) async fn put(mut req: Request<State>) -> Result<Response, Error> {
 
     let mut bytes = Vec::new();
     (&mut req).take(10_000_000).read_to_end(&mut bytes).await?;
-    let mut cursor = std::io::Cursor::new(&bytes);
+    let mut cursor = std::io::Cursor::new(bytes);
 
     let metadata_size = cursor.read_u32::<LittleEndian>()?;
     let mut metadata_bytes = vec![0u8; metadata_size as usize];
@@ -285,12 +317,13 @@ pub(crate) async fn put(mut req: Request<State>) -> Result<Response, Error> {
         };
 
         //? Update keywords.
-        let keywords = metadata.keywords.as_ref().map(|vec| vec.as_slice());
-        link_keywords(conn, krate.id, keywords)?;
+        link_keywords(conn, krate.id, metadata.keywords)?;
 
         //? Update categories.
-        let categories = metadata.categories.as_ref().map(|vec| vec.as_slice());
-        link_categories(conn, krate.id, categories)?;
+        link_categories(conn, krate.id, metadata.categories)?;
+
+        //? Update badges.
+        link_badges(conn, krate.id, metadata.badges)?;
 
         //? Store the crate's tarball.
         state.storage.store_crate(

--- a/src/db/models.rs
+++ b/src/db/models.rs
@@ -303,6 +303,46 @@ pub struct NewCrateCategory {
     Associations,
     AsChangeset,
 )]
+#[table_name = "crate_badges"]
+#[belongs_to(Crate, foreign_key = "crate_id")]
+#[primary_key(id)]
+/// Represents a crate's badge in the database.
+pub struct Badge {
+    /// The badge's ID.
+    pub id: i64,
+    /// The crate's ID.
+    pub crate_id: i64,
+    /// The badge's type.
+    pub badge_type: String,
+    /// The badge's parameters.
+    pub params: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Queryable, Insertable)]
+#[table_name = "crate_badges"]
+/// Represents a crate's badge in the database.
+/// suitable to create an entry while letting the database assign it an ID.
+pub struct NewBadge {
+    /// The crate's ID.
+    pub crate_id: i64,
+    /// The badge's type.
+    pub badge_type: String,
+    /// The badge's parameters.
+    pub params: String,
+}
+
+#[derive(
+    Debug,
+    Clone,
+    PartialEq,
+    Serialize,
+    Deserialize,
+    Queryable,
+    Insertable,
+    Identifiable,
+    Associations,
+    AsChangeset,
+)]
 #[table_name = "sessions"]
 #[belongs_to(Author)]
 #[primary_key(id)]

--- a/src/db/schema.rs
+++ b/src/db/schema.rs
@@ -109,6 +109,20 @@ table! {
 }
 
 table! {
+    /// The crate-to-badges (one-to-many) relationship table.
+    crate_badges (id) {
+        /// The relationship's ID.
+        id -> Bigint,
+        /// The crate's ID.
+        crate_id -> Bigint,
+        /// The badge's type.
+        badge_type -> Varchar,
+        /// The badge's parameters (as JSON).
+        params -> Varchar,
+    }
+}
+
+table! {
     /// The user sessions table.
     sessions (id) {
         /// The session's ID.
@@ -141,6 +155,7 @@ joinable!(crate_keywords -> crates (crate_id));
 joinable!(crate_keywords -> keywords (keyword_id));
 joinable!(crate_categories -> crates (crate_id));
 joinable!(crate_categories -> categories (category_id));
+joinable!(crate_badges -> crates (crate_id));
 joinable!(sessions -> authors (author_id));
 joinable!(salts -> authors (author_id));
 
@@ -153,6 +168,7 @@ allow_tables_to_appear_in_same_query!(
     crate_authors,
     crate_keywords,
     crate_categories,
+    crate_badges,
     sessions,
     salts,
 );

--- a/src/frontend/krate.rs
+++ b/src/frontend/krate.rs
@@ -1,8 +1,9 @@
 use diesel::prelude::*;
 use json::json;
+use serde::{Deserialize, Serialize};
 use tide::{Request, Response};
 
-use crate::db::models::{Crate, CrateAuthor, CrateCategory, CrateKeyword, Keyword};
+use crate::db::models::{Badge, Crate, CrateAuthor, CrateCategory, CrateKeyword, Keyword};
 use crate::db::schema::*;
 use crate::db::DATETIME_FORMAT;
 use crate::error::Error;
@@ -12,6 +13,13 @@ use crate::storage::Store;
 use crate::utils;
 use crate::utils::auth::AuthExt;
 use crate::State;
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+struct BadgeRepr {
+    src: String,
+    alt: String,
+    href: Option<String>,
+}
 
 pub(crate) async fn get(req: Request<State>) -> Result<Response, Error> {
     let name = req.param::<String>("crate").unwrap();
@@ -66,6 +74,250 @@ pub(crate) async fn get(req: Request<State>) -> Result<Response, Error> {
             .select(categories::name)
             .load::<String>(conn)?;
 
+        //? Get the badges of this crate.
+        let badges = Badge::belonging_to(&crate_desc).load::<Badge>(conn)?;
+        let badges: Vec<BadgeRepr> = badges
+            .into_iter()
+            .filter_map(|badge| match badge.badge_type.as_str() {
+                "appveyor" => {
+                    #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+                    struct Params {
+                        repository: String,
+                        branch: Option<String>,
+                        service: Option<String>,
+                        project_name: Option<String>,
+                        id: Option<String>,
+                    }
+                    let params: Params = json::from_str(badge.params.as_str()).ok()?;
+
+                    let repository = params.repository;
+                    let branch = params.branch.unwrap_or_else(|| String::from("master"));
+                    let service = params.service.unwrap_or_else(|| String::from("github"));
+                    let project_name = params
+                        .project_name
+                        .unwrap_or_else(|| repository.replace('.', "-").replace('_', "-"));
+
+                    let src = if let Some(id) = params.id {
+                        format!(
+                            "https://ci.appveyor.com/api/projects/status/{}/branch/{}?svg=true",
+                            id, branch,
+                        )
+                    } else {
+                        format!(
+                            "https://ci.appveyor.com/api/projects/status/{}/{}?branch={}&svg=true",
+                            service, repository, branch,
+                        )
+                    };
+                    let alt = format!("Appveyor build status for the {} branch", branch);
+                    let href = Some(format!("https://ci.appveyor.com/project/{}", project_name));
+                    Some(BadgeRepr { src, alt, href })
+                }
+                "circle-ci" => {
+                    #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+                    struct Params {
+                        repository: String,
+                        branch: Option<String>,
+                    }
+                    let params: Params = json::from_str(badge.params.as_str()).ok()?;
+
+                    let repository = params.repository;
+                    let branch = params.branch.unwrap_or_else(|| String::from("master"));
+
+                    let src = format!(
+                        "https://circleci.com/gh/{}/tree/{}.svg?style=shield",
+                        repository, branch
+                    );
+                    let alt = format!("Circle CI build status for the {} branch", branch);
+                    let href = Some(format!("https://circleci.com/gh/{}", repository));
+                    Some(BadgeRepr { src, alt, href })
+                }
+                "cirrus-ci" => {
+                    #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+                    struct Params {
+                        repository: String,
+                        branch: Option<String>,
+                    }
+                    let params: Params = json::from_str(badge.params.as_str()).ok()?;
+
+                    let repository = params.repository;
+                    let branch = params.branch.unwrap_or_else(|| String::from("master"));
+
+                    let src = format!(
+                        "https://api.cirrus-ci.com/github/{}.svg?branch={}",
+                        repository, branch
+                    );
+                    let alt = format!("Cirrus CI build status for the {} branch", branch);
+                    let href = Some(format!("https://cirrus-ci.com/github/{}", repository));
+                    Some(BadgeRepr { src, alt, href })
+                }
+                "gitlab" => {
+                    #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+                    struct Params {
+                        repository: String,
+                        branch: Option<String>,
+                    }
+                    let params: Params = json::from_str(badge.params.as_str()).ok()?;
+
+                    let repository = params.repository;
+                    let branch = params.branch.unwrap_or_else(|| String::from("master"));
+
+                    let src = format!(
+                        "https://gitlab.com/{}/badges/{}/pipeline.svg",
+                        repository, branch
+                    );
+                    let alt = format!("GitLab build status for the {} branch", branch);
+                    let href = Some(format!("https://gitlab.com/{}/pipelines", repository));
+                    Some(BadgeRepr { src, alt, href })
+                }
+                "azure-devops" => {
+                    #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+                    struct Params {
+                        project: String,
+                        pipeline: String,
+                        build: Option<String>,
+                    }
+                    let params: Params = json::from_str(badge.params.as_str()).ok()?;
+
+                    let project = params.project;
+                    let pipeline = params.pipeline;
+                    let build = params.build.unwrap_or_else(|| String::from("1"));
+
+                    let src = format!(
+                        "https://dev.azure.com/{}/_apis/build/status/{}",
+                        project, pipeline
+                    );
+                    let alt = format!("Azure Devops build status for the {} pipeline", pipeline);
+                    let href = Some(format!(
+                        "https://dev.azure.com/{}/_build/latest?definitionId={}",
+                        project, build
+                    ));
+                    Some(BadgeRepr { src, alt, href })
+                }
+                "travis-ci" => {
+                    #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+                    struct Params {
+                        repository: String,
+                        branch: Option<String>,
+                    }
+                    let params: Params = json::from_str(badge.params.as_str()).ok()?;
+
+                    let repository = params.repository;
+                    let branch = params.branch.unwrap_or_else(|| String::from("master"));
+
+                    let src = format!("https://travis-ci.org/{}.svg?branch={}", repository, branch);
+                    let alt = format!("Travis CI build status for the {} branch", branch);
+                    let href = Some(format!("https://travis-ci.org/{}", repository));
+                    Some(BadgeRepr { src, alt, href })
+                }
+                "codecov" => {
+                    #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+                    struct Params {
+                        repository: String,
+                        branch: Option<String>,
+                        service: Option<String>,
+                    }
+                    let params: Params = json::from_str(badge.params.as_str()).ok()?;
+
+                    let repository = params.repository;
+                    let branch = params.branch.unwrap_or_else(|| String::from("master"));
+                    let service = params.service.unwrap_or_else(|| String::from("github"));
+
+                    let src = format!(
+                        "https://codecov.io/{}/{}/coverage.svg?branch={}",
+                        service, repository, branch
+                    );
+                    let alt = format!("CodeCov coverage status for the {} branch", branch);
+                    let href = Some(format!(
+                        "https://codecov.io/{}/{}?branch={}",
+                        service, repository, branch
+                    ));
+                    Some(BadgeRepr { src, alt, href })
+                }
+                "coveralls" => {
+                    #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+                    struct Params {
+                        repository: String,
+                        branch: Option<String>,
+                        service: Option<String>,
+                    }
+                    let params: Params = json::from_str(badge.params.as_str()).ok()?;
+
+                    let repository = params.repository;
+                    let branch = params.branch.unwrap_or_else(|| String::from("master"));
+                    let service = params.service.unwrap_or_else(|| String::from("github"));
+
+                    let src = format!(
+                        "https://coveralls.io/repos/{}/{}/badge.svg?branch={}",
+                        service, repository, branch
+                    );
+                    let alt = format!("Coveralls coverage status for the {} branch", branch);
+                    let href = Some(format!(
+                        "https://coveralls.io/{}/{}?branch={}",
+                        service, repository, branch
+                    ));
+                    Some(BadgeRepr { src, alt, href })
+                }
+                "is-it-maintained-issue-resolution" => {
+                    #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+                    struct Params {
+                        repository: String,
+                    }
+                    let params: Params = json::from_str(badge.params.as_str()).ok()?;
+
+                    let repository = params.repository;
+
+                    let src = format!(
+                        "https://isitmaintained.com/badge/resolution/{}.svg",
+                        repository
+                    );
+                    let alt = format!("Is It Maintained average time to resolve an issue");
+                    let href = Some(format!("https://isitmaintained.com/project/{}", repository));
+                    Some(BadgeRepr { src, alt, href })
+                }
+                "is-it-maintained-open-issues" => {
+                    #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+                    struct Params {
+                        repository: String,
+                    }
+                    let params: Params = json::from_str(badge.params.as_str()).ok()?;
+
+                    let repository = params.repository;
+
+                    let src = format!("https://isitmaintained.com/badge/open/{}.svg", repository);
+                    let alt = format!("Is It Maintained percentage of issues still open");
+                    let href = Some(format!("https://isitmaintained.com/project/{}", repository));
+                    Some(BadgeRepr { src, alt, href })
+                }
+                "maintenance" => {
+                    #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+                    struct Params {
+                        status: String,
+                    }
+                    let params: Params = json::from_str(badge.params.as_str()).ok()?;
+
+                    let status = params.status.replace('-', "--");
+                    let color = match status.as_str() {
+                        "actively-developed" => "brightgreen",
+                        "passively-maintained" => "yellowgreen",
+                        "as-is" => "yellow",
+                        "experimental" => "blue",
+                        "looking-for-maintainer" => "orange",
+                        "deprecated" => "red",
+                        _ => "blue",
+                    };
+
+                    let src = format!(
+                        "https://img.shields.io/badge/maintenance-{}-{}.svg",
+                        status, color
+                    );
+                    let alt = format!("Maintenance intention for this crate");
+                    let href = None;
+                    Some(BadgeRepr { src, alt, href })
+                }
+                _ => None,
+            })
+            .collect();
+
         let created_at =
             chrono::NaiveDateTime::parse_from_str(crate_desc.created_at.as_str(), DATETIME_FORMAT)
                 .unwrap();
@@ -89,6 +341,7 @@ pub(crate) async fn get(req: Request<State>) -> Result<Response, Error> {
                 "repository": crate_desc.repository,
                 "yanked": krate.yanked,
             },
+            "badges": badges,
             "authors": authors,
             "rendered_readme": rendered_readme,
             "keywords": keywords,

--- a/src/utils/rendering.rs
+++ b/src/utils/rendering.rs
@@ -37,7 +37,7 @@ pub fn render_readme(config: &SyntectState, contents: &str) -> String {
             Event::Start(Tag::CodeBlock(info)) => {
                 let theme = &config.themes.themes[&config.theme_name];
 
-                highlighter = Some(match info.split(' ').next() {
+                highlighter = Some(match info.trim().split(',').next() {
                     Some(lang) => {
                         let syntax = config
                             .syntaxes

--- a/syntect-themes/frontier-contrast.tmTheme
+++ b/syntect-themes/frontier-contrast.tmTheme
@@ -340,7 +340,7 @@ Find more themes at : https://github.com/rainglow
             <key>settings</key>
             <dict>
                 <key>foreground</key>
-                <string>#00A8C6</string>
+                <string>#E51F44</string>
             </dict>
         </dict>
         <dict>

--- a/templates/crate.hbs
+++ b/templates/crate.hbs
@@ -39,20 +39,40 @@
             text-align: center;
         }
 
-        .keywords-container {
+        .keywords-container,
+        .badges-container {
             width: 100%;
             display: flex;
             align-items: center;
             justify-content: center;
+            flex-direction: row;
         }
 
-        .keywords {
+        .keyword {
             font-weight: bold;
             margin-left: 10px;
         }
 
-        .keywords:first-child {
+        .keyword:first-child {
             margin-left: 0;
+        }
+
+        .badges-container {
+            margin-top: 5px;
+        }
+
+        .badge {
+            margin-left: 5px;
+        }
+
+        .badge:first-child {
+            margin-left: 0;
+        }
+
+        .badge-img {
+            display: flex;
+            align-items: center;
+            justify-content: center;
         }
 
         .stats-container {
@@ -225,11 +245,30 @@
             <div class="hero-subtitle">{{ crate.description }}</div>
         </div>
     </div>
+    {{#if keywords}}
     <div class="keywords-container">
         {{#each keywords}}
-        <div class="keywords">#{{ this.name }}</div>
+        <div class="keyword">#{{ this.name }}</div>
         {{/each}}
     </div>
+    {{/if}}
+    {{#if badges}}
+    <div class="badges-container">
+        {{#each badges}}
+        <div class="badge">
+            {{#if this.href}}
+            <a href="{{ this.href }}">
+            {{/if}}
+                <div class="badge-img">
+                    <img src="{{ this.src }}" alt="{{ this.alt }}" title="{{ this.alt }}">
+                </div>
+            {{#if this.href}}
+            </a>
+            {{/if}}
+        </div>
+        {{/each}}
+    </div>
+    {{/if}}
     <div class="stats-container">
         <div class="stats">
             <div class="stats-block">
@@ -263,17 +302,6 @@
                     {{/each}}
                 </div>
                 {{/if}}
-                {{#each badges}}
-                <div class="stat stat-badge">
-                    {{#if this.href}}
-                    <a href="{{ this.href }}">
-                    {{/if}}
-                        <img src="{{ this.src }}" alt="{{ this.alt }}" title="{{ this.alt }}">
-                    {{#if this.href}}    
-                    </a>
-                    {{/if}}
-                </div>
-                {{/each}}
             </div>
         </div>
     </div>

--- a/templates/crate.hbs
+++ b/templates/crate.hbs
@@ -46,6 +46,7 @@
             align-items: center;
             justify-content: center;
             flex-direction: row;
+            flex-wrap: wrap;
         }
 
         .keyword {

--- a/templates/crate.hbs
+++ b/templates/crate.hbs
@@ -95,6 +95,12 @@
             font-weight: bold;
         }
 
+        .stat-badge {
+            display: flex;
+            align-items: center;
+            margin-top: 2px;
+        }
+
         .crate-container {
             width: 100%;
             display: flex;
@@ -119,6 +125,10 @@
 
             .stats {
                 width: 90%;
+            }
+
+            .hero-title, .hero-subtitle {
+                max-width: 90%;
             }
         }
 
@@ -253,6 +263,17 @@
                     {{/each}}
                 </div>
                 {{/if}}
+                {{#each badges}}
+                <div class="stat stat-badge">
+                    {{#if this.href}}
+                    <a href="{{ this.href }}">
+                    {{/if}}
+                        <img src="{{ this.src }}" alt="{{ this.alt }}" title="{{ this.alt }}">
+                    {{#if this.href}}    
+                    </a>
+                    {{/if}}
+                </div>
+                {{/each}}
             </div>
         </div>
     </div>


### PR DESCRIPTION
This PR adds support for showing and keeping track of the badges that crates can specify in the `[badges]` section of their `Cargo.toml` file.  
All the badges, with all their options, mentioned in [**The Cargo Book**](https://doc.rust-lang.org/cargo/reference/manifest.html#package-metadata) are supported.  