### PR TITLE
Improved search bar with suggestions

### DIFF
--- a/src/api/crates/mod.rs
+++ b/src/api/crates/mod.rs
@@ -8,6 +8,8 @@ pub mod owners;
 pub mod publish;
 /// Search endpoint (eg. "/api/v1/crates?q=\<term\>").
 pub mod search;
+/// Suggestion endpoint (eg. "/api/v1/crates/suggest?q=\<term\>").
+pub mod suggest;
 /// Crate unyanking endpoint (eg. "/api/v1/crates/\<name\>/\<version\>/unyank").
 pub mod unyank;
 /// Crate yanking endpoint (eg. "/api/v1/crates/\<name\>/\<version\>/yank").

--- a/src/api/crates/search.rs
+++ b/src/api/crates/search.rs
@@ -38,7 +38,7 @@ struct SearchMeta {
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-struct SearchParams {
+struct QueryParams {
     pub q: String,
     pub per_page: Option<NonZeroU32>,
     pub page: Option<NonZeroU32>,
@@ -47,7 +47,7 @@ struct SearchParams {
 /// Route to search through crates (used by `cargo search`).
 pub(crate) async fn get(req: Request<State>) -> tide::Result {
     let params = req
-        .query::<SearchParams>()
+        .query::<QueryParams>()
         .map_err(|_| AlexError::MissingQueryParams {
             missing_params: &["q"],
         })?;

--- a/src/api/crates/suggest.rs
+++ b/src/api/crates/suggest.rs
@@ -1,0 +1,76 @@
+use std::num::NonZeroU32;
+
+use diesel::prelude::*;
+use semver::Version;
+use serde::{Deserialize, Serialize};
+use tide::{Request, Response};
+
+use crate::db::models::CrateRegistration;
+use crate::db::schema::*;
+
+use crate::error::{AlexError, Error};
+use crate::index::Indexer;
+use crate::utils;
+use crate::State;
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+struct APIResponse {
+    pub suggestions: Vec<Suggestion>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+struct Suggestion {
+    pub name: String,
+    pub vers: Version,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+struct QueryParams {
+    pub q: String,
+    pub limit: Option<NonZeroU32>,
+}
+
+/// Route to search through crates (used by `cargo search`).
+pub(crate) async fn get(req: Request<State>) -> Result<Response, Error> {
+    let params = req
+        .query::<QueryParams>()
+        .map_err(|_| AlexError::MissingQueryParams {
+            missing_params: &["q"],
+        })?;
+    let state = req.state().clone();
+    let repo = &state.repo;
+
+    //? Fetch the latest index changes.
+    // state.index.refresh()?;
+
+    //? Build the search pattern.
+    let name_pattern = format!("%{0}%", params.q.replace('\\', "\\\\").replace('%', "\\%"));
+
+    //? Limit the result count depending on parameters.
+    let limit = params.limit.map_or(10, |limit| i64::from(limit.get()));
+
+    //? Fetch results.
+    let results = repo
+        .run(move |conn| {
+            crates::table
+                .filter(crates::name.like(name_pattern.as_str()))
+                .limit(limit)
+                .load::<CrateRegistration>(conn)
+        })
+        .await?;
+
+    //? Fetch version information about these crates.
+    let suggestions = results
+        .into_iter()
+        .map(|krate| {
+            let latest = state.index.latest_record(krate.name.as_str())?;
+            Ok(Suggestion {
+                name: krate.name,
+                vers: latest.vers,
+            })
+        })
+        .collect::<Result<Vec<Suggestion>, Error>>()?;
+
+    let data = APIResponse { suggestions };
+    Ok(utils::response::json(&data))
+}

--- a/src/api/crates/suggest.rs
+++ b/src/api/crates/suggest.rs
@@ -3,9 +3,9 @@ use std::num::NonZeroU32;
 use diesel::prelude::*;
 use semver::Version;
 use serde::{Deserialize, Serialize};
-use tide::{Request, Response};
+use tide::Request;
 
-use crate::db::models::CrateRegistration;
+use crate::db::models::Crate;
 use crate::db::schema::*;
 
 use crate::error::{AlexError, Error};
@@ -31,7 +31,7 @@ struct QueryParams {
 }
 
 /// Route to search through crates (used by `cargo search`).
-pub(crate) async fn get(req: Request<State>) -> Result<Response, Error> {
+pub(crate) async fn get(req: Request<State>) -> tide::Result {
     let params = req
         .query::<QueryParams>()
         .map_err(|_| AlexError::MissingQueryParams {
@@ -55,7 +55,7 @@ pub(crate) async fn get(req: Request<State>) -> Result<Response, Error> {
             crates::table
                 .filter(crates::name.like(name_pattern.as_str()))
                 .limit(limit)
-                .load::<CrateRegistration>(conn)
+                .load::<Crate>(conn)
         })
         .await?;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -166,6 +166,9 @@ async fn run() -> Result<(), Error> {
     app.at("/api/v1/crates").get(api::crates::search::get);
     info!("mounting '/api/v1/crates/new'");
     app.at("/api/v1/crates/new").put(api::crates::publish::put);
+    info!("mounting '/api/v1/crates/suggest'");
+    app.at("/api/v1/crates/suggest")
+        .get(api::crates::suggest::get);
     info!("mounting '/api/v1/crates/:name'");
     app.at("/api/v1/crates/:name").get(api::crates::info::get);
     info!("mounting '/api/v1/crates/:name/owners'");

--- a/templates/account/manage.hbs
+++ b/templates/account/manage.hbs
@@ -281,28 +281,9 @@
             background-color: var(--dark-bg-color);
         }
 
-        .manage-tokens-entry-revoke-dis {
-            width: 100%;
-            height: 100%;
-            display: flex;
-            align-items: center;
-            justify-content: center;
-            color: var(--fg-color);
-            background-color: var(--lighter-bg-color);
-            padding: 5px 10px;
-            box-shadow: 0 0 10px #0006;
-            border-radius: 5px;
-            cursor: pointer;
-            transition: transform 0.15s;
-        }
-
         .manage-tokens-entry-revoke::before {
             font-family: alexicons;
             /* content: "\e901"; */
-        }
-
-        .manage-tokens-entry-revoke-dis:hover {
-            transform: scale(1.1);
         }
 
         .manage-tokens-empty {

--- a/templates/crate.hbs
+++ b/templates/crate.hbs
@@ -167,7 +167,6 @@
         .readme pre {
             padding: 20px;
             border-radius: 5px;
-            box-shadow: 0 0 10px #0006;
             overflow-x: auto;
         }
 

--- a/templates/index.hbs
+++ b/templates/index.hbs
@@ -163,7 +163,6 @@
             color: var(--fg-color);
             background-color: var(--lighter-bg-color);
             padding: 10px 20px;
-            box-shadow: 0 0 10px #0006;
             border-radius: 10px;
             cursor: pointer;
             transition: transform 0.15s;
@@ -204,7 +203,6 @@
             font-weight: bold;
             font-size: 20px;
             display: block;
-            box-shadow: 0 0 10px #0006;
             border-radius: 30px;
             color: var(--fg-color);
             background-color: var(--light-bg-color);
@@ -273,7 +271,7 @@
                 <div class="most-downloaded-entries">
                     {{#if most_downloaded}}
                     {{#each most_downloaded}}
-                    <a class="most-downloaded-entry" href="/crates/{{ this.name }}">
+                    <a class="most-downloaded-entry elevated" href="/crates/{{ this.name }}">
                         <b>{{ this.name }}</b>: {{ this.downloads }} downloads
                     </a>
                     {{/each}}
@@ -282,7 +280,7 @@
                     {{/if}}
                 </div>
                 <div class="card-footer">
-                    <a class="card-footer-button" href="/most-downloaded">See more...</a>
+                    <a class="card-footer-button elevated" href="/most-downloaded">See more...</a>
                 </div>
             </div>
             <div class="last-updated">
@@ -290,7 +288,7 @@
                 <div class="last-updated-entries">
                     {{#if last_updated}}
                     {{#each last_updated}}
-                    <a class="last-updated-entry" href="/crates/{{ this.name }}">
+                    <a class="last-updated-entry elevated" href="/crates/{{ this.name }}">
                         <b>{{ this.name }}</b>: {{ this.updated_at }}
                     </a>
                     {{/each}}
@@ -299,7 +297,7 @@
                     {{/if}}
                 </div>
                 <div class="card-footer">
-                    <a class="card-footer-button" href="/last-updated">See more...</a>
+                    <a class="card-footer-button elevated" href="/last-updated">See more...</a>
                 </div>
             </div>
         </div>

--- a/templates/last-updated.hbs
+++ b/templates/last-updated.hbs
@@ -275,10 +275,10 @@
     </div>
     <div class="search-results-container">
         {{> partials/pagination pagination}}
-        <div class="search-results elevated">
+        <div class="search-results">
             {{#if results}}
             {{#each results}}
-            <a class="search-result" href="/crates/{{ this.name }}">
+            <a class="search-result elevated" href="/crates/{{ this.name }}">
                 <div class="search-result-infos">
                     <div class="search-result-title">
                         {{ this.name }} #{{ this.version }}

--- a/templates/last-updated.hbs
+++ b/templates/last-updated.hbs
@@ -89,7 +89,6 @@
             background-color: var(--lighter-bg-color);
             color: var(--fg-color);
             padding: 20px;
-            box-shadow: 0 0 10px #0006;
             border-radius: 10px;
             cursor: pointer;
             transition: transform 0.15s;
@@ -276,7 +275,7 @@
     </div>
     <div class="search-results-container">
         {{> partials/pagination pagination}}
-        <div class="search-results">
+        <div class="search-results elevated">
             {{#if results}}
             {{#each results}}
             <a class="search-result" href="/crates/{{ this.name }}">

--- a/templates/most-downloaded.hbs
+++ b/templates/most-downloaded.hbs
@@ -89,7 +89,6 @@
             background-color: var(--lighter-bg-color);
             color: var(--fg-color);
             padding: 20px;
-            box-shadow: 0 0 10px #0006;
             border-radius: 10px;
             cursor: pointer;
             transition: transform 0.15s;
@@ -279,7 +278,7 @@
         <div class="search-results">
             {{#if results}}
             {{#each results}}
-            <a class="search-result" href="/crates/{{ this.name }}">
+            <a class="search-result elevated" href="/crates/{{ this.name }}">
                 <div class="search-result-infos">
                     <div class="search-result-title">
                         {{ this.name }} #{{ this.version }}

--- a/templates/partials/head.hbs
+++ b/templates/partials/head.hbs
@@ -27,6 +27,7 @@
         --fg-color: #272727;
         --dark-fg-color: #202020;
         --darker-fg-color: #171717;
+        --secondary-fg-color: #888;
 
         --lighter-bg-color: #FFF;
         --light-bg-color: #F0F0F0;

--- a/templates/partials/head.hbs
+++ b/templates/partials/head.hbs
@@ -68,4 +68,8 @@
     *::after {
         box-sizing: border-box;
     }
+
+    .elevated {
+        box-shadow: 0 6px 16px rgba(0, 0, 0, 0.2), 0 0 4px rgba(0, 0, 0, 0.05);
+    }
 </style>

--- a/templates/partials/navbar.hbs
+++ b/templates/partials/navbar.hbs
@@ -138,6 +138,11 @@
         background-color: var(--bg-color);
     }
 
+    .navbar-search-results-entry-version {
+        font-size: 13px;
+        color: var(--secondary-fg-color);
+    }
+
     .navbar-search-results-empty {
         height: 150px;
         display: flex;
@@ -375,7 +380,11 @@
                 const div = document.createElement("div");
                 div.classList.add("navbar-search-results-entry");
                 div.setAttribute("tabindex", "0");
-                div.textContent = `${name} v${vers}`;
+                div.textContent = `${name} `;
+                const span = document.createElement("span");
+                span.classList.add("navbar-search-results-entry-version");
+                span.textContent = `v${vers}`;
+                div.appendChild(span);
                 link.appendChild(div);
                 entries.appendChild(link);
             }

--- a/templates/partials/navbar.hbs
+++ b/templates/partials/navbar.hbs
@@ -376,10 +376,9 @@
             entries.innerHTML = "";
             for ({ name, vers } of data.suggestions) {
                 const link = document.createElement("a");
+                link.classList.add("navbar-search-results-entry");
                 link.setAttribute("href", urlT`/crates/${name}`);
                 const div = document.createElement("div");
-                div.classList.add("navbar-search-results-entry");
-                div.setAttribute("tabindex", "0");
                 div.textContent = `${name} `;
                 const span = document.createElement("span");
                 span.classList.add("navbar-search-results-entry-version");

--- a/templates/partials/navbar.hbs
+++ b/templates/partials/navbar.hbs
@@ -13,8 +13,6 @@
         color: var(--fg-color);
         background-color: var(--lighter-bg-color);
         border-radius: 5px;
-        box-shadow: 0 0 15px #00000060;
-        overflow: hidden;
     }
 
     .navbar-tag {
@@ -68,6 +66,12 @@
         justify-content: flex-end;
     }
 
+    .navbar-search-overall {
+        position: relative;
+        z-index: 1;
+        height: 100%;
+    }
+
     .navbar-search {
         appearance: none;
         -moz-appearance: none;
@@ -87,9 +91,59 @@
         outline: none;
     }
 
-    .navbar-search:focus {
+    .navbar-search-container:focus-within .navbar-search {
         width: 320px;
         border: 2px solid var(--darker-bg-color);
+    }
+
+    .navbar-search-container:focus-within .navbar-search-results {
+        display: inherit;
+    }
+
+    .navbar-search-results {
+        position: absolute;
+        top: -5px;
+        left: -5px;
+        right: -5px;
+        z-index: -1;
+        padding: 5px;
+        overflow: hidden;
+        display: none;
+        background-color: var(--lighter-bg-color);
+        border-radius: 5px;
+    }
+
+    .navbar-search-results-spacer {
+        width: 100%;
+        height: 33.5px;
+        margin-bottom: 5px;
+        background-color: var(--lighter-bg-color);
+    }
+
+    .navbar-search-results-entries {
+        width: 100%;
+        display: grid;
+        grid-gap: 5px;
+        grid-template-columns: 100%;
+    }
+
+    .navbar-search-results-entry {
+        padding: 5px 10px;
+        font-weight: bold;
+        border-radius: 5px;
+    }
+
+    .navbar-search-results-entry:hover,
+    .navbar-search-results-entry:focus {
+        background-color: var(--bg-color);
+    }
+
+    .navbar-search-results-empty {
+        height: 150px;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        font-weight: bold;
     }
 
     .navbar-login-container {
@@ -146,7 +200,6 @@
         color: var(--fg-color);
         background-color: var(--lighter-bg-color);
         border-radius: 5px;
-        box-shadow: 0 0 15px #00000060;
         overflow: hidden;
         opacity: 0;
         transform: scale(0.7);
@@ -172,12 +225,18 @@
             display: flex;
         }
 
+        .navbar-tag:hover {
+            background-color: var(--darker-fg-color) !important;
+            color: var(--darker-bg-color) !important;
+        }
+
         .navbar-search-container form {
             justify-content: center;
         }
 
         .navbar-search,
-        .navbar-search:focus {
+        .navbar-search-overall,
+        .navbar-search-container:focus-within .navbar-search {
             width: 100%;
         }
 
@@ -219,13 +278,13 @@
     }
 
     @media (prefers-color-scheme: dark) {
-        .navbar-search:focus {
+        .navbar-search-container:focus-within .navbar-search {
             border: 2px solid var(--darker-fg-color);
         }
     }
 </style>
 <input class="navbar-burger-input" type="checkbox" id="burger-checkbox" hidden>
-<div class="navbar">
+<div class="navbar elevated">
     <div class="navbar-brand-container">
         <a class="navbar-brand navbar-tag" href="/">
             {{ instance.title }}
@@ -233,7 +292,15 @@
     </div>
     <div class="navbar-search-container">
         <form method="GET" action="/search">
-            <input type="text" class="navbar-search" name="q" placeholder="Search crate...">
+            <div class="navbar-search-overall">
+                <input type="text" class="navbar-search" name="q" placeholder="Search crate..." autocomplete="off">
+                <div class="navbar-search-results elevated">
+                    <div class="navbar-search-results-spacer"></div>
+                    <div class="navbar-search-results-entries">
+                        <div class="navbar-search-results-empty">No suggestions...</div>
+                    </div>
+                </div>
+            </div>
         </form>
     </div>
     <div class="navbar-login-container">
@@ -265,3 +332,57 @@
         {{/if}}
     </div>
 </div>
+<script>
+    function debounced(delay, fn) {
+        let timerID;
+        return function (...args) {
+            if (timerID) {
+                clearTimeout(timerID);
+            }
+            timerID = setTimeout(() => {
+                fn(...args);
+                timerID = null;
+            }, delay);
+        }
+    }
+
+    // template string tag to URL-encode every interpolated expressions.
+    const urlT = (strings, ...exprs) => {
+        const [head, ...tail] = strings;
+        return tail.reduce((acc, elem, idx) => [...acc, encodeURIComponent(exprs[idx]), elem], [head]).join("");
+    };
+
+    const handler = event => {
+        const query = event.target.value;
+        if (query.length == 0) {
+            const [entries] = document.getElementsByClassName("navbar-search-results-entries");
+            entries.innerHTML = "";
+            const empty = document.createElement("div");
+            empty.classList.add("navbar-search-results-empty");
+            empty.textContent = "No suggestions...";
+            entries.appendChild(empty);
+            return;
+        }
+        const url = urlT`/api/v1/crates/suggest?q=${query}`;
+        (async () => {
+            const response = await fetch(url, { mode: "same-origin", credentials: "same-origin" });
+            const data = await response.json();
+            const [entries] = document.getElementsByClassName("navbar-search-results-entries");
+            entries.innerHTML = "";
+            for ({ name, vers } of data.suggestions) {
+                const link = document.createElement("a");
+                link.setAttribute("href", urlT`/crates/${name}`);
+                const div = document.createElement("div");
+                div.classList.add("navbar-search-results-entry");
+                div.setAttribute("tabindex", "0");
+                div.textContent = `${name} v${vers}`;
+                link.appendChild(div);
+                entries.appendChild(link);
+            }
+        })();
+    };
+
+    const debouncedHandler = debounced(250, handler);
+    const input = document.querySelector('input[type="text"].navbar-search');
+    input.addEventListener("input", debouncedHandler);
+</script>

--- a/templates/search.hbs
+++ b/templates/search.hbs
@@ -89,7 +89,6 @@
             background-color: var(--lighter-bg-color);
             color: var(--fg-color);
             padding: 20px;
-            box-shadow: 0 0 10px #0006;
             border-radius: 10px;
             cursor: pointer;
             transition: transform 0.15s;
@@ -279,7 +278,7 @@
         <div class="search-results">
             {{#if results}}
             {{#each results}}
-            <a class="search-result" href="/crates/{{ this.name }}">
+            <a class="search-result elevated" href="/crates/{{ this.name }}">
                 <div class="search-result-infos">
                     <div class="search-result-title">
                         {{ this.name }} #{{ this.version }}


### PR DESCRIPTION
This PR adds improvements to the frontend's search bar by providing suggestions as the user types to improve the search experience. 

The suggestions are provided by a new endpoint in the programmatic API:  
`/api/v1/crates/suggest?q={some-query}&limit={some-limit}`

The suggestions are lighter to load than full search results (just names and versions) but are capped to at most 10 results, but the programmatic API endpoint allows to change that cap.

![alexandrie-search-suggestions](https://user-images.githubusercontent.com/4294633/73587496-753dae00-44b4-11ea-8abb-b3990e652701.gif)
(The GIF is slowed down, I don't know why. :/)