### PR TITLE
Added separate `user` and `password_file` options in database configuration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -54,6 +54,7 @@ dependencies = [
  "tide 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "url 2.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ tide = { version = "0.5.0" }
 http = { version = "0.1.21" }
 
 # data types
+url = { version = "2.1.1" }
 semver = { version = "0.9.0", features = ["serde"] }
 chrono = { version = "0.4.10", features = ["serde"] }
 

--- a/src/config/database.rs
+++ b/src/config/database.rs
@@ -5,6 +5,12 @@ use serde::{Deserialize, Serialize};
 pub struct DatabaseConfig {
     /// The database connection URL.
     pub url: String,
+    /// The username to use when connecting to the database.
+    #[cfg(any(feature = "mysql", feature = "postgres"))]
+    pub user: Option<String>,
+    /// The path to a file storing the password to use when connecting to the database.
+    #[cfg(any(feature = "mysql", feature = "postgres"))]
+    pub password_file: Option<String>,
     /// The maximum number of concurrent database connections.
     pub max_conns: Option<u32>,
 }

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -75,13 +75,9 @@ where
             }
             if let Some(file) = database_config.password_file.as_ref() {
                 if url.password().is_none() {
-                    let file = File::open(file).expect("could not open the database password file");
-                    let password = BufReader::new(file)
-                        .lines()
-                        .next()
-                        .expect("could not read password from the database password file")
-                        .expect("could not read password from the database password file");
-                    url.set_password(Some(password.trim()))
+                    let password = std::fs::read_to_string(file)
+                        .expect("could not read from the database password file");
+                    url.set_password(Some(password))
                         .expect("could not append password to the connection URL");
                 } else {
                     panic!("conflicting passwords in database configuration");

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -1,6 +1,3 @@
-use std::fs::File;
-use std::io::{BufRead, BufReader};
-
 use diesel::r2d2::{self, ConnectionManager, Pool, PooledConnection};
 use url::Url;
 
@@ -77,7 +74,7 @@ where
                 if url.password().is_none() {
                     let password = std::fs::read_to_string(file)
                         .expect("could not read from the database password file");
-                    url.set_password(Some(password))
+                    url.set_password(Some(password.as_str()))
                         .expect("could not append password to the connection URL");
                 } else {
                     panic!("conflicting passwords in database configuration");

--- a/src/main.rs
+++ b/src/main.rs
@@ -89,6 +89,7 @@ embed_migrations!("migrations/postgres");
 use futures::future::{BoxFuture, FutureExt};
 use std::future::Future;
 use tide::{Endpoint, IntoResponse, Request, Response};
+
 struct Handler<F> {
     handler: F,
 }


### PR DESCRIPTION
This PR adds the following optional configuration options to `[database]`:
```toml
[database]
user = "root"
password_file = "~/file.txt"
```

This code contains multiple calls to `.expect("...")` and `panic!("...")`, which is not great but fine for configuration code (the application is not truely started yet and we wish to stop execution early).  
But I'll be investigating to improve how errors are handled more generally, both inside and outside endpoint handlers.  

The current implementation will panic if a username or password is specified both in the connection URL and its specific option.  

**Closes #30.**