### PR TITLE
Removed defaults for creation and modification dates in database

### DIFF
--- a/migrations/mysql/2019-10-12-193526_initialise/up.sql
+++ b/migrations/mysql/2019-10-12-193526_initialise/up.sql
@@ -8,8 +8,8 @@ create table crates (
     id bigint not null auto_increment unique primary key,
     name varchar(255) not null unique,
     description varchar(4096),
-    created_at varchar(25) not null default concat(utc_date(), " ", utc_time()),
-    updated_at varchar(25) not null default concat(utc_date(), " ", utc_time()),
+    created_at varchar(25) not null,
+    updated_at varchar(25) not null,
     downloads bigint not null default 0,
     documentation varchar(1024),
     repository varchar(1024)

--- a/migrations/postgres/2019-10-12-193526_initialise/up.sql
+++ b/migrations/postgres/2019-10-12-193526_initialise/up.sql
@@ -8,8 +8,8 @@ create table crates (
     id bigserial primary key,
     name varchar(255) not null unique,
     description varchar(4096),
-    created_at varchar(25) not null default (to_char(CURRENT_TIMESTAMP at time zone 'UTC', 'YYYY-MM-DD HH24:MI:SS')),
-    updated_at varchar(25) not null default (to_char(CURRENT_TIMESTAMP at time zone 'UTC', 'YYYY-MM-DD HH24:MI:SS')),
+    created_at varchar(25) not null,
+    updated_at varchar(25) not null,
     downloads bigint not null default 0,
     documentation varchar(1024),
     repository varchar(1024)

--- a/migrations/sqlite/2019-10-12-193526_initialise/up.sql
+++ b/migrations/sqlite/2019-10-12-193526_initialise/up.sql
@@ -8,8 +8,8 @@ create table crates (
     id integer primary key,
     name varchar(255) not null unique,
     description varchar(4096),
-    created_at varchar(25) not null default (datetime('now')),
-    updated_at varchar(25) not null default (datetime('now')),
+    created_at varchar(25) not null,
+    updated_at varchar(25) not null,
     downloads bigint not null default 0,
     documentation varchar(1024),
     repository varchar(1024)

--- a/src/api/search.rs
+++ b/src/api/search.rs
@@ -6,7 +6,7 @@ use semver::Version;
 use serde::{Deserialize, Serialize};
 use tide::{Request, Response};
 
-use crate::db::models::CrateRegistration;
+use crate::db::models::Crate;
 use crate::db::schema::*;
 use crate::db::DATETIME_FORMAT;
 use crate::error::{AlexError, Error};
@@ -71,20 +71,20 @@ pub(crate) async fn get(req: Request<State>) -> Result<Response, Error> {
                     .filter(crates::name.like(name_pattern.as_str()))
                     .limit(i64::from(per_page.get()))
                     .offset(i64::from((page.get() - 1) * per_page.get()))
-                    .load::<CrateRegistration>(conn)?
+                    .load::<Crate>(conn)?
             }
             (Some(per_page), None) => {
                 //? Get the first page of search results with the given entries per page.
                 crates::table
                     .filter(crates::name.like(name_pattern.as_str()))
                     .limit(i64::from(per_page.get()))
-                    .load::<CrateRegistration>(conn)?
+                    .load::<Crate>(conn)?
             }
             _ => {
                 //? Get ALL the crates (might be too much, tbh).
                 crates::table
                     .filter(crates::name.like(name_pattern.as_str()))
-                    .load::<CrateRegistration>(conn)?
+                    .load::<Crate>(conn)?
             }
         };
 

--- a/src/db/models.rs
+++ b/src/db/models.rs
@@ -16,7 +16,7 @@ use crate::db::schema::*;
 #[table_name = "crates"]
 #[primary_key(id)]
 /// Represents a complete crate entry, as stored in the database.
-pub struct CrateRegistration {
+pub struct Crate {
     /// The crate's ID.
     pub id: i64,
     /// The crate's name.
@@ -35,43 +35,19 @@ pub struct CrateRegistration {
     pub repository: Option<String>,
 }
 
-#[derive(
-    Debug,
-    Clone,
-    PartialEq,
-    Serialize,
-    Deserialize,
-    Queryable,
-    Insertable,
-    Identifiable,
-    AsChangeset,
-)]
-#[table_name = "crates"]
-#[primary_key(id)]
-/// Represents a partial crate entry from the database,
-/// suitable to edit an entry while letting the database maintain the updated date of the row.
-pub struct ModifyCrateRegistration<'a> {
-    /// The crate's ID.
-    pub id: i64,
-    /// The crate's name.
-    pub name: &'a str,
-    /// The crate's description.
-    pub description: Option<&'a str>,
-    /// The URL to the crate's documentation.
-    pub documentation: Option<&'a str>,
-    /// The URL to the crate's repository.
-    pub repository: Option<&'a str>,
-}
-
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Queryable, Insertable)]
 #[table_name = "crates"]
 /// Represents a partial crate entry from the database,
-/// suitable to create an entry while letting the database assign an ID and set the creation date of the row.
-pub struct NewCrateRegistration<'a> {
+/// suitable to create an entry while letting the database assign it an ID.
+pub struct NewCrate<'a> {
     /// The crate's name.
     pub name: &'a str,
     /// The crate's description.
     pub description: Option<&'a str>,
+    /// The crate's creation date.
+    pub created_at: &'a str,
+    /// The crate's last updated date.
+    pub updated_at: &'a str,
     /// The URL to the crate's documentation.
     pub documentation: Option<&'a str>,
     /// The URL to the crate's repository.
@@ -130,7 +106,7 @@ pub struct NewAuthor<'a> {
 )]
 #[table_name = "crate_authors"]
 #[belongs_to(Author)]
-#[belongs_to(CrateRegistration, foreign_key = "crate_id")]
+#[belongs_to(Crate, foreign_key = "crate_id")]
 #[primary_key(id)]
 /// Represents a crate-to-author relationship in the database.
 pub struct CrateAuthor {
@@ -229,7 +205,7 @@ pub struct Keyword {
 )]
 #[table_name = "crate_keywords"]
 #[belongs_to(Keyword)]
-#[belongs_to(CrateRegistration, foreign_key = "crate_id")]
+#[belongs_to(Crate, foreign_key = "crate_id")]
 #[primary_key(id)]
 /// Represents a crate-to-keyword relationship in the database.
 pub struct CrateKeyword {
@@ -292,7 +268,7 @@ pub struct Category {
 )]
 #[table_name = "crate_categories"]
 #[belongs_to(Category)]
-#[belongs_to(CrateRegistration, foreign_key = "crate_id")]
+#[belongs_to(Crate, foreign_key = "crate_id")]
 #[primary_key(id)]
 /// Represents a crate-to-category relationship in the database.
 pub struct CrateCategory {

--- a/src/frontend/krate.rs
+++ b/src/frontend/krate.rs
@@ -2,7 +2,7 @@ use diesel::prelude::*;
 use json::json;
 use tide::{Request, Response};
 
-use crate::db::models::{CrateAuthor, CrateCategory, CrateKeyword, CrateRegistration, Keyword};
+use crate::db::models::{Crate, CrateAuthor, CrateCategory, CrateKeyword, Keyword};
 use crate::db::schema::*;
 use crate::db::DATETIME_FORMAT;
 use crate::error::Error;
@@ -26,7 +26,7 @@ pub(crate) async fn get(req: Request<State>) -> Result<Response, Error> {
         //? Get this crate's data.
         let crate_desc = crates::table
             .filter(crates::name.eq(&name))
-            .first::<CrateRegistration>(conn)
+            .first::<Crate>(conn)
             .optional()?;
         let crate_desc = match crate_desc {
             Some(crate_desc) => crate_desc,

--- a/src/frontend/last_updated.rs
+++ b/src/frontend/last_updated.rs
@@ -6,7 +6,7 @@ use json::json;
 use serde::{Deserialize, Serialize};
 use tide::{Request, Response};
 
-use crate::db::models::CrateRegistration;
+use crate::db::models::Crate;
 use crate::db::schema::*;
 use crate::db::DATETIME_FORMAT;
 use crate::error::Error;
@@ -38,7 +38,7 @@ pub(crate) async fn get(req: Request<State>) -> Result<Response, Error> {
             .first::<i64>(conn)?;
 
         //? Get the search results for the given page number.
-        let results: Vec<CrateRegistration> = crates::table
+        let results: Vec<Crate> = crates::table
             .order_by(crates::updated_at.desc())
             .limit(15)
             .offset(15 * i64::from(page_number - 1))
@@ -54,7 +54,7 @@ pub(crate) async fn get(req: Request<State>) -> Result<Response, Error> {
                     .load::<String>(conn)?;
                 Ok((result, keywords))
             })
-            .collect::<Result<Vec<(CrateRegistration, Vec<String>)>, Error>>()?;
+            .collect::<Result<Vec<(Crate, Vec<String>)>, Error>>()?;
 
         //? Make page number starts counting from 1 (instead of 0).
         let page_count = (total_results / 15

--- a/src/frontend/most_downloaded.rs
+++ b/src/frontend/most_downloaded.rs
@@ -6,7 +6,7 @@ use json::json;
 use serde::{Deserialize, Serialize};
 use tide::{Request, Response};
 
-use crate::db::models::CrateRegistration;
+use crate::db::models::Crate;
 use crate::db::schema::*;
 use crate::db::DATETIME_FORMAT;
 use crate::error::Error;
@@ -38,7 +38,7 @@ pub(crate) async fn get(req: Request<State>) -> Result<Response, Error> {
             .first::<i64>(conn)?;
 
         //? Get the search results for the given page number.
-        let results: Vec<CrateRegistration> = crates::table
+        let results: Vec<Crate> = crates::table
             .order_by(crates::downloads.desc())
             .limit(15)
             .offset(15 * i64::from(page_number - 1))
@@ -54,7 +54,7 @@ pub(crate) async fn get(req: Request<State>) -> Result<Response, Error> {
                     .load::<String>(conn)?;
                 Ok((result, keywords))
             })
-            .collect::<Result<Vec<(CrateRegistration, Vec<String>)>, Error>>()?;
+            .collect::<Result<Vec<(Crate, Vec<String>)>, Error>>()?;
 
         //? Make page number starts counting from 1 (instead of 0).
         let page_count = (total_results / 15

--- a/src/frontend/search.rs
+++ b/src/frontend/search.rs
@@ -6,7 +6,7 @@ use json::json;
 use serde::{Deserialize, Serialize};
 use tide::{Request, Response};
 
-use crate::db::models::CrateRegistration;
+use crate::db::models::Crate;
 use crate::db::schema::*;
 use crate::db::DATETIME_FORMAT;
 use crate::error::Error;
@@ -42,7 +42,7 @@ pub(crate) async fn get(req: Request<State>) -> Result<Response, Error> {
             .first::<i64>(conn)?;
 
         //? Get the search results for the given page number.
-        let results: Vec<CrateRegistration> = crates::table
+        let results: Vec<Crate> = crates::table
             .filter(crates::name.like(q.as_str()))
             .limit(15)
             .offset(15 * i64::from(page_number - 1))
@@ -58,7 +58,7 @@ pub(crate) async fn get(req: Request<State>) -> Result<Response, Error> {
                     .load::<String>(conn)?;
                 Ok((result, keywords))
             })
-            .collect::<Result<Vec<(CrateRegistration, Vec<String>)>, Error>>()?;
+            .collect::<Result<Vec<(Crate, Vec<String>)>, Error>>()?;
 
         //? Make page number starts counting from 1 (instead of 0).
         let page_count = (total_results / 15

--- a/src/index/models.rs
+++ b/src/index/models.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 /// Represents a crate version record.
 ///
 /// This is what's stored in the crate index.  
-/// Note that this structs represents only a specific version of a crate.
+/// Note that this struct represents only a specific version of a crate.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct CrateVersion {
     /// The name of the crate.


### PR DESCRIPTION
This PR removes the default values for the `created_at` and `updated_at` columns of the `crates` table in all database schemas.  
So the crate publication routine now specifies any or both of these upon insertion or modification of that table.  

As an aside, this PR also renames `CrateRegistration` (in `crate::db::models`) to just `Crate`.

**Closes #32.**
