### PR TITLE
Added .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,24 @@
+# by default, exclude everything
+**
+
+# make exceptions for what we actually want
+# (this is done to avoid accidentally including secrets in the build context)
+!assets
+!Cargo.lock
+!diesel.toml
+!docker/sqlite/alexandrie.toml
+!docker/sqlite/Cargo.toml
+!docker/mysql/alexandrie.toml
+!docker/mysql/Cargo.toml
+!docker/mysql/mysql-compose.yaml
+!docker/postgresql/alexandrie.toml
+!docker/postgresql/Cargo.toml
+!docker/postgresql/postgresql-compose.yaml
+!docker/startup.sh
+!migrations
+!src
+!syntect-dumps
+!syntect-syntaxes
+!syntect-themes
+!templates
+!wasm-pbkdf2


### PR DESCRIPTION
Ignores everything by default, and manually includes the items that will actually be used in the image

I tried doing something like this:

```ignore
!docker/*/alexandrie.toml
!docker/*/Cargo.toml
!docker/*/*-compose.yaml
```

But the Dockerfile failed at the first COPY that needed one of these (which happened to be Cargo.toml), so I instead had to copy/paste those lines for each database type