### PR TITLE
Fixed missing dependency in Docker builds

### DIFF
--- a/docker/mysql/Cargo.toml
+++ b/docker/mysql/Cargo.toml
@@ -18,6 +18,7 @@ tide = { version = "0.5.0" }
 http = { version = "0.1.21" }
 
 # data types
+url = { version = "2.1.1" }
 semver = { version = "0.9.0", features = ["serde"] }
 chrono = { version = "0.4.10", features = ["serde"] }
 

--- a/docker/postgresql/Cargo.toml
+++ b/docker/postgresql/Cargo.toml
@@ -18,6 +18,7 @@ tide = { version = "0.5.0" }
 http = { version = "0.1.21" }
 
 # data types
+url = { version = "2.1.1" }
 semver = { version = "0.9.0", features = ["serde"] }
 chrono = { version = "0.4.10", features = ["serde"] }
 

--- a/docker/sqlite/Cargo.toml
+++ b/docker/sqlite/Cargo.toml
@@ -18,6 +18,7 @@ tide = { version = "0.5.0" }
 http = { version = "0.1.21" }
 
 # data types
+url = { version = "2.1.1" }
 semver = { version = "0.9.0", features = ["serde"] }
 chrono = { version = "0.4.10", features = ["serde"] }
 

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -1,5 +1,4 @@
 use diesel::r2d2::{self, ConnectionManager, Pool, PooledConnection};
-use url::Url;
 
 use crate::config::database::DatabaseConfig;
 
@@ -61,6 +60,8 @@ where
         let database_url = database_config.url.as_str();
         #[cfg(any(feature = "mysql", feature = "postgres"))]
         let database_url = {
+            use url::Url;
+
             let mut url = Url::parse(database_config.url.as_str()).expect("invalid connection URL");
             if let Some(user) = database_config.user.as_ref() {
                 if url.username().is_empty() {
@@ -70,6 +71,7 @@ where
                     panic!("conflicting usernames in database configuration");
                 }
             }
+
             if let Some(file) = database_config.password_file.as_ref() {
                 if url.password().is_none() {
                     let password = std::fs::read_to_string(file)
@@ -80,6 +82,7 @@ where
                     panic!("conflicting passwords in database configuration");
                 }
             }
+
             url.to_string()
         };
 


### PR DESCRIPTION
This PR fixes the missing `url` dependency in the `Cargo.toml` files used for Docker builds.  
It also eliminates the warning `unused import: url::Url` for MySQL and PostgreSQL setups.

**Closes #48.**
