### PR TITLE
Added more API endpoints for managing tokens

### DIFF
--- a/src/api/account/mod.rs
+++ b/src/api/account/mod.rs
@@ -2,5 +2,5 @@
 pub mod login;
 /// Account registration endpoint (eg. "/api/v1/account/register").
 pub mod register;
-/// Token-related endpoints (eg. "/api/v1/account/token/*").
+/// Token-related endpoints (eg. "/api/v1/account/tokens/*").
 pub mod token;

--- a/src/api/account/token/info.rs
+++ b/src/api/account/token/info.rs
@@ -18,8 +18,62 @@ pub struct RequestBody {
 /// Response body for this route.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ResponseBody {
+    /// The token name.
+    pub name: String,
     /// The expiration date for this token.
     pub expires_at: Option<String>,
+}
+
+/// Route to get information about a registry token.
+pub async fn get(req: Request<State>) -> Result<Response, Error> {
+    let name = req.param::<String>("name").unwrap();
+
+    let state = req.state().clone();
+    let repo = &state.repo;
+
+    //? Is the author logged in ?
+    let headers = req.headers().clone();
+    let author = repo
+        .run(move |conn| utils::checks::get_author(conn, &headers))
+        .await;
+    let author = match author {
+        Some(author) => author,
+        None => {
+            return Ok(utils::response::error(
+                StatusCode::UNAUTHORIZED,
+                "please log in first to access token information",
+            ));
+        }
+    };
+
+    //? Fetch the token from the database.
+    let token = repo
+        .run(move |conn| {
+            author_tokens::table
+                .filter(author_tokens::name.eq(name.as_str()))
+                .filter(author_tokens::author_id.eq(author.id))
+                .first::<AuthorToken>(conn)
+                .optional()
+        })
+        .await?;
+
+    //? Was a token found ?
+    let token = match token {
+        Some(token) => token,
+        None => {
+            return Ok(utils::response::error(
+                StatusCode::NOT_FOUND,
+                "no token was found for the supplied name",
+            ))
+        }
+    };
+
+    let expires_at = None;
+    let response = ResponseBody {
+        name: token.name,
+        expires_at,
+    };
+    Ok(utils::response::json(&response))
 }
 
 /// Route to get information about a registry token.
@@ -50,6 +104,7 @@ pub async fn post(mut req: Request<State>) -> Result<Response, Error> {
         .run(move |conn| {
             author_tokens::table
                 .filter(author_tokens::token.eq(body.token.as_str()))
+                .filter(author_tokens::author_id.eq(author.id))
                 .first::<AuthorToken>(conn)
                 .optional()
         })
@@ -66,15 +121,10 @@ pub async fn post(mut req: Request<State>) -> Result<Response, Error> {
         }
     };
 
-    //? Is the token from that same author ?
-    if token.author_id != author.id {
-        return Ok(utils::response::error(
-            StatusCode::FORBIDDEN,
-            "unauthorized access to this token",
-        ));
-    }
-
     let expires_at = None;
-    let response = ResponseBody { expires_at };
+    let response = ResponseBody {
+        name: token.name,
+        expires_at,
+    };
     Ok(utils::response::json(&response))
 }

--- a/src/api/account/token/mod.rs
+++ b/src/api/account/token/mod.rs
@@ -1,7 +1,6 @@
-/// Token information endpoint (eg. "/api/v1/account/token/info").
+/// Token generation endpoint (eg. "PUT /api/v1/account/tokens").
+pub mod generate;
+/// Token information endpoint (eg. "GET /api/v1/account/tokens/\<name\>").
 pub mod info;
-/// Token revocation endpoint (eg. "/api/v1/account/token/revoke").
+/// Token revocation endpoint (eg. "DELETE /api/v1/account/tokens").
 pub mod revoke;
-
-pub use self::info::post;
-pub use self::revoke::delete;

--- a/src/main.rs
+++ b/src/main.rs
@@ -191,10 +191,14 @@ async fn run() -> Result<(), Error> {
     info!("mounting '/api/v1/account/login'");
     app.at("/api/v1/account/login")
         .post(Handler::new(api::account::login::post));
-    info!("mounting '/api/v1/account/token'");
-    app.at("/api/v1/account/token")
-        .post(Handler::new(api::account::token::post))
-        .delete(Handler::new(api::account::token::delete));
+    info!("mounting '/api/v1/account/tokens'");
+    app.at("/api/v1/account/tokens")
+        .post(Handler::new(api::account::token::info::post))
+        .put(Handler::new(api::account::token::generate::put))
+        .delete(Handler::new(api::account::token::revoke::delete));
+    info!("mounting '/api/v1/account/tokens/:name'");
+    app.at("/api/v1/account/tokens/:name")
+        .get(Handler::new(api::account::token::info::get));
     info!("mounting '/api/v1/categories'");
     app.at("/api/v1/categories")
         .get(Handler::new(api::categories::get));


### PR DESCRIPTION
This PR introduces two new endpoints for the programmatic API.  

- **`GET /api/v1/account/tokens/<name>`**: to get information about a token from its name.
- **`PUT /api/v1/account/tokens`**: to generate new authentication tokens.

It also renames the **`/api/v1/account/token`** API namespace to **`/api/v1/account/tokens`**.
