### PR TITLE
Improve documentation around setting up the crate index

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ The database is configured through the `[database]` table:
 
 ```toml
 [database]
-# Replace the '<...>' placeholders by the real values.
+# Replace the '<...>' placeholders by their real actual values.
 
 # For MySQL
 url = "mysql://<user>:<password>@<hostname>:<port>/<database>"
@@ -62,7 +62,7 @@ url = "mysql://<user>:<password>@<hostname>:<port>/<database>"
 url = "postgresql://<user>:<password>@<hostname>:<port>/<database>"
 
 # For SQLite
-url = "<path-to-sqlite-file>"
+url = "<path-to-sqlite-database-file>"
 # or:
 url = ":memory:" # ephemeral in-memory database, doesn't persists between restarts
 ```
@@ -101,8 +101,14 @@ The default for it is `./crate-index`.
 To clone an existing crate index, you can run:
 
 ```bash
-# Replace the '<...>' placeholders by the real ones.
+# Replace the '<...>' placeholders by their real actual values.
 git clone <url-of-the-crate-index> <path-from-config>
+
+# <url-of-the-crate-index>: URL to the git repository serving as the registry's crate index.
+# <path-from-config>: Path to the same directory as the one specified as `index.path` in the `alexandrie.toml`.
+
+# Example:
+git clone 'https://github.com/Hirevo/alexandrie-index' 'crate-index'
 ```
 
 If you want to create one, you can refer to the [Cargo's Alternative Registries RFC] to learn about the layout of such an index.  
@@ -117,9 +123,13 @@ Then, if you want to use this index with Cargo, you can follow these steps:
 
 - Edit or create the `~/.cargo/config` file, and add the following code:
   ```toml
-  # Replace the '<...>' placeholders by the real ones.
+  # Replace the '<...>' placeholders by their real actual values.
   [registries.<name-of-your-registry>]
   index = "<url-of-the-crate-index>"
+
+  # <name-of-your-registry>: A name of your choosing, that you'll be using to refer to it in `cargo` commands.
+  # <url-of-the-crate-index>: URL to the git repository serving as the registry's crate index.
+  #                           BE CAREFUL: this is not the URL to the registry's API or frontend.
   ```
 - Then, run `cargo login --registry <name-of-your-registry>` and enter your author token.  
   To generate a token, you need to register as an author first.

--- a/README.md
+++ b/README.md
@@ -96,6 +96,16 @@ addr = "127.0.0.1"
 port = 3000
 ```
 
+Then, you need to configure a crate index.  
+A crate index is simply a git repository that the registry uses to keep metadata information about each crate and their individual versions.  
+The repository can be created on any machine you want, as long as it is reachable from the current machine as a git remote in a clone of that repository.  
+The remote can be specified using either an HTTPS or SSH link.  
+
+_If you're using SSH for the remote link, Cargo might have an issue where it can't fetch from the registry's index when doing `cargo search` or `cargo build`._  
+_This is because Cargo uses `libgit2` to fetch from remotes and fails to find the SSH credentials needed to do so._  
+_To work around this issue, you may need to set the `CARGO_NET_GIT_FETCH_WITH_CLI` environment variable to `true`, so that Cargo will offload the fetching from remotes operation to the `git` command-line utility._  
+_See [issue #44](https://github.com/Hirevo/alexandrie/issues/44) for a previous occurence of this exact issue._  
+
 To run the registry, be sure to clone your crate index at the location designated by the `path` key in `[index]`.  
 The default for it is `./crate-index`.  
 To clone an existing crate index, you can run:
@@ -138,7 +148,6 @@ Then, if you want to use this index with Cargo, you can follow these steps:
   - Generating a token at `/account/manage`.
 - You can now use the registry using `cargo [search|publish] --registry <name-of-your-registry>`
 
-
 `docker-compose`
 -------
 
@@ -168,7 +177,6 @@ To stop Alexandrie, do:
 ```
 
 The script assumes a Bash environment, and was only tested on Ubuntu 19.10. For more details and examples, see the docs.
-
 
 License
 -------

--- a/README.md
+++ b/README.md
@@ -148,8 +148,15 @@ Then, if you want to use this index with Cargo, you can follow these steps:
   - Generating a token at `/account/manage`.
 - You can now use the registry using `cargo [search|publish] --registry <name-of-your-registry>`
 
-`docker-compose`
--------
+Installation script
+-------------------
+
+If you wish to have a more concrete resource to learn how to setup an Alexandrie instance, like a shell script, you may refer to an example installation script which can help you get started:
+
+**<https://hirevo.github.io/alexandrie/installation-script.html>**
+
+Docker Compose
+--------------
 
 You can host Alexandrie in a Docker container on your computer or a host machine of your choosing. You will need both [docker](https://docs.docker.com/install/) and [docker-compose](https://docs.docker.com/compose/install/) installed.
 

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -3,6 +3,7 @@ Summary
 
 - [Introduction](./introduction.md)
 - [Getting started](./getting-started.md)
+- [Installation script](./installation-script.md)
 - [Concepts](./concepts/mod.md)
   - [Crate index](./concepts/crate-index.md)
   - [Crate storage](./concepts/crate-storage.md)

--- a/docs/src/getting-started.md
+++ b/docs/src/getting-started.md
@@ -69,6 +69,16 @@ addr = "127.0.0.1"  # Endpoint on which to serve the service.
 port = 3000         # Port on which to serve the service.
 ```
 
+Then, you need to configure a crate index.  
+A crate index is simply a git repository that the registry uses to keep metadata information about each crate and their individual versions.  
+The repository can be created on any machine you want, as long as it is reachable from the current machine as a git remote in a clone of that repository.  
+The remote can be specified using either an HTTPS or SSH link.  
+
+_If you're using SSH for the remote link, Cargo might have an issue where it can't fetch from the registry's index when doing `cargo search` or `cargo build`._  
+_This is because Cargo uses `libgit2` to fetch from remotes and fails to find the SSH credentials needed to do so._  
+_To work around this issue, you may need to set the `CARGO_NET_GIT_FETCH_WITH_CLI` environment variable to `true`, so that Cargo will offload the fetching from remotes operation to the `git` command-line utility._  
+_See [issue #44](https://github.com/Hirevo/alexandrie/issues/44) for a previous occurence of this exact issue._  
+
 To run the registry with the configuration above, be sure to clone your crate index at the location designated by the `path` key in `[index]`.  
 In this case, it is `./crate-index`.  
 To clone an existing crate index, you can run:

--- a/docs/src/getting-started.md
+++ b/docs/src/getting-started.md
@@ -124,3 +124,10 @@ Then, if you want to use this index with Cargo, you can follow these steps:
   - Registering at `/account/register`.
   - Generating a token at `/account/manage`.
 - You can now use the registry using `cargo [search|publish] --registry <name-of-your-registry>`
+
+Installation script
+-------------------
+
+If you wish to have a more concrete resource to learn how to setup an Alexandrie instance, like a shell script, you may refer to an example installation script which can help you get started:
+
+**<https://hirevo.github.io/alexandrie/installation-script.html>**

--- a/docs/src/getting-started.md
+++ b/docs/src/getting-started.md
@@ -31,7 +31,7 @@ The database is configured through the `[database]` table:
 
 ```toml
 [database]
-# Replace the '<...>' placeholders by the real values.
+# Replace the '<...>' placeholders by their real actual values.
 
 # For MySQL
 url = "mysql://<user>:<password>@<hostname>:<port>/<database>"
@@ -40,7 +40,7 @@ url = "mysql://<user>:<password>@<hostname>:<port>/<database>"
 url = "postgresql://<user>:<password>@<hostname>:<port>/<database>"
 
 # For SQLite
-url = "<path-to-sqlite-file>"
+url = "<path-to-sqlite-database-file>"
 # or:
 url = ":memory:" # ephemeral in-memory database, doesn't persists between restarts
 ```
@@ -74,8 +74,14 @@ In this case, it is `./crate-index`.
 To clone an existing crate index, you can run:
 
 ```bash
-# Replace the '<...>' placeholders by the real ones.
+# Replace the '<...>' placeholders by their real actual values.
 git clone <url-of-the-crate-index> <path-from-config>
+
+# <url-of-the-crate-index>: URL to the git repository serving as the registry's crate index.
+# <path-from-config>: Path to the same directory as the one specified as `index.path` in the `alexandrie.toml`.
+
+# Example:
+git clone 'https://github.com/Hirevo/alexandrie-index' 'crate-index'
 ```
 
 If you want to create one, you can refer to the [**Cargo's Alternative Registries RFC**][Cargo's Alternative Registries RFC] to learn about the layout of such an index.  
@@ -94,9 +100,13 @@ Then, if you want to use this index with Cargo, you can follow these steps:
 
 - Edit or create the `~/.cargo/config` file, and add the following code:
   ```toml
-  # Replace the '<...>' placeholders by the real ones.
+  # Replace the '<...>' placeholders by their real actual values.
   [registries.<name-of-your-registry>]
   index = "<url-of-the-crate-index>"
+
+  # <name-of-your-registry>: A name of your choosing, that you'll be using to refer to it in `cargo` commands.
+  # <url-of-the-crate-index>: URL to the git repository serving as the registry's crate index.
+  #                           BE CAREFUL: this is not the URL to the registry's API or frontend.
   ```
 - Then, run `cargo login --registry <name-of-your-registry>` and enter your author token.  
   To generate a token, you need to register as an author first.

--- a/docs/src/installation-script.md
+++ b/docs/src/installation-script.md
@@ -46,7 +46,7 @@ fi
 
 if [ -d "$ALEXANDRIE_DIR" ]; then
     echo
-    echo "'{}' (ALEXANDRIE_DIR) is an existing directory, pulling latest changes ...";
+    echo "'$ALEXANDRIE_DIR' (ALEXANDRIE_DIR) is an existing directory, pulling latest changes ...";
     cd "$ALEXANDRIE_DIR";
     git pull;
     echo "Changes have been pulled successfully !";

--- a/docs/src/installation-script.md
+++ b/docs/src/installation-script.md
@@ -1,0 +1,112 @@
+Installation script
+===================
+
+Rather than reading paragraphs of text, you may prefer to learn the steps to setup an Alexandrie instance through a simple shell script.  
+
+Here is such a script that you can use to configure an initial instance of Alexandrie, but keep in mind that:  
+
+**This script is not a substitute for the actual documentation.**  
+**You may need to configure/change a few things, even after running the script.**  
+**It is only there to help you get started and/or be a more concrete documentation resource.**  
+
+```bash
+#!/bin/bash
+
+# function to run when an error is encountered
+function setup_error {
+    echo "-------- An error occurred during configuration --------"
+    exit 1
+}
+
+# exit on error
+trap 'setup_error' ERR
+
+# directory to clone Alexandrie into:
+ALEXANDRIE_DIR="";
+
+# URL to the crate index repository.
+CRATE_INDEX_GIT_URL="$1";
+
+while [ -z "$ALEXANDRIE_DIR" ]; then
+    read -p 'Directory to clone/find Alexandrie into: ' ALEXANDRIE_DIR;
+fi
+
+while ! git ls-remote -h $CRATE_INDEX_GIT_URL; do
+    read -p 'CRATE_INDEX_GIT_URL: ' CRATE_INDEX_GIT_URL;
+done
+
+if ! cargo -V; then
+    echo;
+    echo "In order to build an instance of Alexandrie, you need to have Rust installed on your system";
+    echo "You can learn how to install Rust on your system on the official Rust website:";
+    echo "https://www.rust-lang.org/tools/install";
+    echo;
+    ! :;    # trigger error trap
+fi
+
+if [ -d "$ALEXANDRIE_DIR" ]; then
+    echo
+    echo "'{}' (ALEXANDRIE_DIR) is an existing directory, pulling latest changes ...";
+    cd "$ALEXANDRIE_DIR";
+    git pull;
+    echo "Changes have been pulled successfully !";
+    echo;
+else
+    echo;
+    echo "Cloning Alexandrie in '$ALEXANDRIE_DIR' ...";
+    git clone https://github.com/Hirevo/alexandrie.git "$ALEXANDRIE_DIR";
+    cd "$ALEXANDRIE_DIR";
+    echo "Successfully cloned Alexandrie !";
+    echo;
+fi
+
+echo "Building Alexandrie (using the default features)...";
+echo "(keep in mind that the default features may not fit your use-case, be sure to review them before deplying it to production)";
+cargo build -p alexandrie;
+echo "Alexandrie has been built successfully !";
+
+# create the directory serving as the storage of crate archives.
+mkdir -p crate-storage;
+
+# setup the crate index.
+if [ -d crate-index ]; then
+    echo;
+    echo "'${ALEXANDRIE_DIR}/crate-index' is an existing directory, pulling latest changes ...";
+    cd crate-index;
+    git pull;
+    echo "Changes have been pulled successfully !";
+    echo;
+else
+    echo;
+    echo "Cloning crate index in '${ALEXANDRIE_DIR}/crate-index' ...";
+    git clone "$CRATE_INDEX_GIT_URL" crate-index;
+    cd crate-index;
+    echo "Successfully cloned the crate index !";
+    echo;
+fi
+
+# configure the crate index
+if [ ! -f config.json ]; then
+    echo "The crate index does not have a 'config.json' file.";
+    echo "Creating an initial one (please also review it before deploying the registry in production) ..."
+    cat > config.json << EOF;
+{
+    "dl": "http://$(hostname):3000/api/v1/crates/{crate}/{version}/download",
+    "api": "http://$(hostname):3000",
+    "allowed-registries": ["https://github.com/rust-lang/crates.io-index"]
+}
+EOF
+    git add config.json;
+    git commit -m 'Added `config.json`';
+    git push -u origin master;
+    echo "Initial 'config.json' file has been created and pushed to the crate index !";
+    echo;
+fi
+
+echo "Alexandrie should be good to go for an initial run.";
+echo "You can start the Alexandrie instance by:";
+echo "  - navigating to '${ALEXANDRIE_DIR}'";
+echo "  - tweaking the 'alexandrie.toml' file";
+echo "  - run `./target/debug/alexandrie`";
+echo;
+```


### PR DESCRIPTION
This PR adds more details in documentation about what is the crate index and how to setup one.  

It adds explainers for various `<...>` placeholders in documentation for values that users have to fill in for their specific installation.  
It adds a few lines explaining what is the crate index and how to setup one (also mentions the SSH issue and its workaround).  
It also adds an example shell script, written from the one that @kuruczalbert wrote in **#69**.

**Fixes #69**
