### PR TITLE
Upgraded Rust version used for E2E tests to `1.44`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 #
 
 ### First stage: build the application
-FROM rust:1.40-slim-buster as builder
+FROM rust:1.44-slim-buster as builder
 
 ARG DATABASE
 

--- a/e2e/images/runner/Dockerfile
+++ b/e2e/images/runner/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.40
+FROM rust:1.44
 
 # install a few system dependencies
 RUN apt update


### PR DESCRIPTION
This PR upgrades the Rust toolchain version used for End-to-End tests from `1.40` to `1.44`.  
This fixes the issue with the use of the rather new `matches!(...)` macro by Tide 0.12, that we're currently upgrading Alexandrie to.  