### PR TITLE
Allow for more freedom for the server's binding address configuration

### DIFF
--- a/alexandrie.toml
+++ b/alexandrie.toml
@@ -1,6 +1,5 @@
 [general]
-addr = "127.0.0.1"
-port = 3000
+bind_address = "127.0.0.1:3000"
 
 [frontend]
 enabled = true

--- a/alexandrie/src/config/mod.rs
+++ b/alexandrie/src/config/mod.rs
@@ -1,5 +1,3 @@
-use std::net;
-
 use serde::{Deserialize, Serialize};
 
 /// Database configuration (`[database]` section).
@@ -25,10 +23,8 @@ pub use crate::config::frontend::*;
 /// The general configuration options struct.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct GeneralConfig {
-    /// The host address to bind on.
-    pub addr: net::IpAddr,
-    /// The port to listen on.
-    pub port: u16,
+    /// The address to bind the server on.
+    pub bind_address: String,
 }
 
 /// The application configuration struct.

--- a/docker/mysql/alexandrie.toml
+++ b/docker/mysql/alexandrie.toml
@@ -6,8 +6,7 @@
 #
 
 [general]
-addr = "0.0.0.0"
-port = 3000
+bind_address = "0.0.0.0:3000"
 
 [frontend]
 enabled = true

--- a/docker/postgres/alexandrie.toml
+++ b/docker/postgres/alexandrie.toml
@@ -6,8 +6,7 @@
 #
 
 [general]
-addr = "0.0.0.0"
-port = 3000
+bind_address = "0.0.0.0:3000"
 
 [frontend]
 enabled = true

--- a/docker/sqlite/alexandrie.toml
+++ b/docker/sqlite/alexandrie.toml
@@ -6,8 +6,7 @@
 #
 
 [general]
-addr = "0.0.0.0"
-port = 3000
+bind_address = "0.0.0.0:3000"
 
 [frontend]
 enabled = true


### PR DESCRIPTION
This PR changes how the server's binding address is specified in Alexandrie's configuration.  
This change allows to specify more ways to make the server available.  

One notable example of such a use case is wanting Alexandrie to operate over a Unix Domain Socket (UDS), which was previously not possible because Alexandrie required to specify an IP and a port number, which is of no use for UDS which only needs a filesystem path to a socket file.  

Now, all these cases should be handled:
```toml
[general]
bind_address = "127.0.0.1:3000"  # only serve on the loopback interface on port 3000
# bind_address = "::1:3000"      # (IPv6 version)

# or:
bind_address = "0.0.0.0:3000"    # serve on all interfaces on port 3000
# bind_address = ":::3000"       # (IPv6 version)

# or:
bind_address = "http+unix:///home/user/alexandrie.sock"  # serve over an Unix Domain Socket on the specified path
```

**Fixes #73.**