### PR TITLE
Simplify code using the combinators for `Option`

### DIFF
--- a/alexandrie/src/utils/request_log.rs
+++ b/alexandrie/src/utils/request_log.rs
@@ -22,17 +22,8 @@ impl<State: Clone + Send + Sync + 'static> Middleware<State> for RequestLogger {
         let res = next.run(req).await;
         let elapsed = start.elapsed().as_millis();
         let status = res.status();
-        let resp_msg = {
-            if let Some(err) = res.error() {
-                err.to_string()
-            } else {
-                "OK".into()
-            }
-        };
-        info!(
-            "--> {} {} {} {}ms , {}",
-            method, path, status, elapsed, resp_msg
-        );
+        let msg = res.error().map(|e| e.to_string()).unwrap_or("OK".into());
+        info!("--> {} {} {} {}ms , {}", method, path, status, elapsed, msg);
         Ok(res)
     }
 }

--- a/alexandrie/src/utils/request_log.rs
+++ b/alexandrie/src/utils/request_log.rs
@@ -22,7 +22,10 @@ impl<State: Clone + Send + Sync + 'static> Middleware<State> for RequestLogger {
         let res = next.run(req).await;
         let elapsed = start.elapsed().as_millis();
         let status = res.status();
-        let msg = res.error().map(|e| e.to_string()).unwrap_or("OK".into());
+        let msg = res
+            .error()
+            .map(|err| err.to_string())
+            .unwrap_or_else(|| "OK".to_string());
         info!("--> {} {} {} {}ms , {}", method, path, status, elapsed, msg);
         Ok(res)
     }


### PR DESCRIPTION
I just list some code about how compare get easy with  get `Result` or `Option`.That avoid not use `unwrap()` method.
So look like it's  easy use with `combinator` method.

# example
```rust
struct Message(usize);

fn get_msg(msg: &Option<Message>) -> String {
    let mut rep_msg = "Ok".to_string();
    if let Some(msg) = msg {
        rep_msg = format!("{}", msg.0)
    }
    rep_msg
}

fn get_msg_1(msg: &Option<Message>) -> String {
    let rep_msg = if let Some(msg) = msg {
        format!("{}", msg.0)
    } else {
        "Ok".to_string()
    };
    rep_msg
}

fn get_msg_2(msg: &Option<Message>) -> String {
    let rep_msg = {
        if let Some(msg) = msg {
            format!("{}", msg.0)
        } else {
            "Ok".to_string()
        }
    };
    rep_msg
}

fn get_msg_3(msg: &Option<Message>) -> String {
    msg.as_ref().map(|msg| format!("{}", msg.0)).unwrap_or("Ok".to_string())
}

#[cfg(test)]
mod tests {
    use super::*;

    #[test]
    fn test_get_msg() {
        let key = Some(Message(32usize));
        let expect = "32".to_string();
        assert_eq!(expect, get_msg(&key));
        assert_eq!(expect, get_msg_1(&key));
        assert_eq!(expect, get_msg_2(&key));
        assert_eq!(expect, get_msg_3(&key));
    }
}
```
with link:[https://github.com/baoyachi/baoyachi.github.io/blob/master/src/Rust/advice_rust_code_with_block.md](https://github.com/baoyachi/baoyachi.github.io/blob/master/src/Rust/advice_rust_code_with_block.md)

