### PR TITLE
Removed a bunch of potentially unexpected panics

### DIFF
--- a/alexandrie/src/frontend/account/login.rs
+++ b/alexandrie/src/frontend/account/login.rs
@@ -28,8 +28,7 @@ struct LoginForm {
 pub(crate) async fn get(mut req: Request<State>) -> tide::Result {
     if let Some(author) = req.get_author() {
         let state = req.state().as_ref();
-        let response = common::already_logged_in(state, author);
-        return Ok(response);
+        return common::already_logged_in(state, author);
     }
 
     let error_msg = req
@@ -42,7 +41,7 @@ pub(crate) async fn get(mut req: Request<State>) -> tide::Result {
         "error_msg": error_msg,
     });
     Ok(utils::response::html(
-        engine.render("account/login", &context).unwrap(),
+        engine.render("account/login", &context)?,
     ))
 }
 
@@ -55,12 +54,12 @@ pub(crate) async fn post(mut req: Request<State>) -> tide::Result {
     let form: LoginForm = match req.body_form().await {
         Ok(form) => form,
         Err(_) => {
-            return Ok(utils::response::error_html(
+            return utils::response::error_html(
                 req.state(),
                 None,
                 StatusCode::BadRequest,
                 "could not deseriailize form data",
-            ));
+            );
         }
     };
 

--- a/alexandrie/src/frontend/account/manage/mod.rs
+++ b/alexandrie/src/frontend/account/manage/mod.rs
@@ -39,8 +39,7 @@ pub(crate) async fn get(mut req: Request<State>) -> tide::Result {
         Some(author) => author,
         None => {
             let state = req.state().as_ref();
-            let response = common::need_to_login(state);
-            return Ok(response);
+            return common::need_to_login(state);
         }
     };
 
@@ -101,7 +100,7 @@ pub(crate) async fn get(mut req: Request<State>) -> tide::Result {
             "token_revocation_error_msg": token_revoke_error_msg,
         });
         Ok(utils::response::html(
-            engine.render("account/manage", &context).unwrap(),
+            engine.render("account/manage", &context)?,
         ))
     });
 

--- a/alexandrie/src/frontend/account/manage/passwd.rs
+++ b/alexandrie/src/frontend/account/manage/passwd.rs
@@ -34,12 +34,12 @@ pub(crate) async fn post(mut req: Request<State>) -> tide::Result {
     let form: ChangePasswordForm = match req.body_form().await {
         Ok(form) => form,
         Err(_) => {
-            return Ok(utils::response::error_html(
+            return utils::response::error_html(
                 req.state(),
                 Some(author),
                 StatusCode::BadRequest,
                 "could not deseriailize form data",
-            ));
+            );
         }
     };
 

--- a/alexandrie/src/frontend/account/manage/tokens/mod.rs
+++ b/alexandrie/src/frontend/account/manage/tokens/mod.rs
@@ -32,12 +32,12 @@ pub(crate) async fn post(mut req: Request<State>) -> tide::Result {
     let form: CreateTokenForm = match req.body_form().await {
         Ok(form) => form,
         Err(_) => {
-            return Ok(utils::response::error_html(
+            return utils::response::error_html(
                 req.state(),
                 Some(author),
                 StatusCode::BadRequest,
                 "could not deseriailize form data",
-            ));
+            );
         }
     };
 

--- a/alexandrie/src/frontend/account/register.rs
+++ b/alexandrie/src/frontend/account/register.rs
@@ -33,8 +33,7 @@ struct RegisterForm {
 pub(crate) async fn get(mut req: Request<State>) -> tide::Result {
     if let Some(author) = req.get_author() {
         let state = req.state().as_ref();
-        let response = common::already_logged_in(state, author);
-        return Ok(response);
+        return common::already_logged_in(state, author);
     }
 
     let error_msg = req
@@ -47,7 +46,7 @@ pub(crate) async fn get(mut req: Request<State>) -> tide::Result {
         "error_msg": error_msg,
     });
     Ok(utils::response::html(
-        engine.render("account/register", &context).unwrap(),
+        engine.render("account/register", &context)?,
     ))
 }
 
@@ -60,12 +59,12 @@ pub(crate) async fn post(mut req: Request<State>) -> tide::Result {
     let form: RegisterForm = match req.body_form().await {
         Ok(form) => form,
         Err(_) => {
-            return Ok(utils::response::error_html(
+            return utils::response::error_html(
                 req.state(),
                 None,
                 StatusCode::BadRequest,
                 "could not deseriailize form data",
-            ));
+            );
         }
     };
 

--- a/alexandrie/src/frontend/index.rs
+++ b/alexandrie/src/frontend/index.rs
@@ -66,7 +66,7 @@ pub(crate) async fn get(req: Request<State>) -> tide::Result {
             }).collect::<Vec<_>>(),
         });
         Ok(utils::response::html(
-            engine.render("index", &context).unwrap(),
+            engine.render("index", &context)?,
         ))
     });
 

--- a/alexandrie/src/frontend/krate.rs
+++ b/alexandrie/src/frontend/krate.rs
@@ -39,13 +39,12 @@ pub(crate) async fn get(req: Request<State>) -> tide::Result {
         let crate_desc = match crate_desc {
             Some(crate_desc) => crate_desc,
             None => {
-                let response = utils::response::error_html(
+                return utils::response::error_html(
                     state.as_ref(),
                     user,
                     StatusCode::NotFound,
                     format!("No crate named '{0}' has been found.", name),
                 );
-                return Ok(response);
             }
         };
         let krate = state.index.latest_record(&crate_desc.name)?;
@@ -347,9 +346,7 @@ pub(crate) async fn get(req: Request<State>) -> tide::Result {
             "keywords": keywords,
             "categories": categories,
         });
-        Ok(utils::response::html(
-            engine.render("crate", &context).unwrap(),
-        ))
+        Ok(utils::response::html(engine.render("crate", &context)?))
     });
 
     transaction.await

--- a/alexandrie/src/frontend/last_updated.rs
+++ b/alexandrie/src/frontend/last_updated.rs
@@ -111,7 +111,7 @@ pub(crate) async fn get(req: Request<State>) -> tide::Result {
             }).collect::<Result<Vec<_>, Error>>()?,
         });
         Ok(utils::response::html(
-            engine.render("last-updated", &context).unwrap(),
+            engine.render("last-updated", &context)?,
         ))
     });
 

--- a/alexandrie/src/frontend/most_downloaded.rs
+++ b/alexandrie/src/frontend/most_downloaded.rs
@@ -111,7 +111,7 @@ pub(crate) async fn get(req: Request<State>) -> tide::Result {
             }).collect::<Result<Vec<_>, Error>>()?,
         });
         Ok(utils::response::html(
-            engine.render("most-downloaded", &context).unwrap(),
+            engine.render("most-downloaded", &context)?,
         ))
     });
 

--- a/alexandrie/src/frontend/search.rs
+++ b/alexandrie/src/frontend/search.rs
@@ -24,7 +24,7 @@ struct SearchParams {
 }
 
 pub(crate) async fn get(req: Request<State>) -> tide::Result {
-    let params = req.query::<SearchParams>().unwrap();
+    let params = req.query::<SearchParams>()?;
     let searched_text = params.q.clone();
     let q = format!("%{0}%", params.q.replace('\\', "\\\\").replace('%', "\\%"));
     let page_number = params.page.map_or_else(|| 1, |page| page.get());
@@ -120,7 +120,7 @@ pub(crate) async fn get(req: Request<State>) -> tide::Result {
             }).collect::<Result<Vec<_>, Error>>()?,
         });
         Ok(utils::response::html(
-            engine.render("search", &context).unwrap(),
+            engine.render("search", &context)?,
         ))
     });
 

--- a/alexandrie/src/main.rs
+++ b/alexandrie/src/main.rs
@@ -224,6 +224,7 @@ async fn main() {
     let _guard = logs::init();
 
     if let Err(err) = run().await {
-        log::error!("{}", err);
+        eprintln!("{}", err);
+        std::process::exit(1);
     }
 }

--- a/alexandrie/src/utils/response/common.rs
+++ b/alexandrie/src/utils/response/common.rs
@@ -1,10 +1,10 @@
-use tide::{Response, StatusCode};
+use tide::StatusCode;
 
 use crate::config::State;
 use crate::db::models::Author;
 
 /// Constructs a response for 'unauthenticated-only' pages.
-pub fn already_logged_in(state: &State, user: Author) -> Response {
+pub fn already_logged_in(state: &State, user: Author) -> tide::Result {
     super::error_html(
         state,
         Some(user),
@@ -14,7 +14,7 @@ pub fn already_logged_in(state: &State, user: Author) -> Response {
 }
 
 /// Constructs a response for 'authenticated-only' pages.
-pub fn need_to_login(state: &State) -> Response {
+pub fn need_to_login(state: &State) -> tide::Result {
     super::error_html(
         state,
         None,

--- a/alexandrie/src/utils/response/mod.rs
+++ b/alexandrie/src/utils/response/mod.rs
@@ -52,14 +52,17 @@ pub fn error_html(
     user: Option<Author>,
     status: StatusCode,
     error_msg: impl AsRef<str>,
-) -> Response {
+) -> tide::Result {
     let engine = &state.frontend.handlebars;
     let context = json!({
         "user": user,
         "instance": &state.frontend.config,
         "error_msg": error_msg.as_ref(),
     });
-    self::html_with_status(status, engine.render("error", &context).unwrap())
+    Ok(self::html_with_status(
+        status,
+        engine.render("error", &context)?,
+    ))
 }
 
 /// Constructs a redirection response (302 Found) to the specified URL.


### PR DESCRIPTION
This PR replaces a lot of unwraps with the `?` operator in order to transform what was previously panics into request-specific errors which won't shut down the whole instance.
