### PR TITLE
Refactor code to use the recently-stabilized slice patterns feature

### DIFF
--- a/alexandrie/src/api/crates/owners.rs
+++ b/alexandrie/src/api/crates/owners.rs
@@ -156,14 +156,13 @@ pub(crate) async fn put(mut req: Request<State>) -> tide::Result {
             .values(new_authors)
             .execute(&**conn)?;
 
-        let authors_list = match new_authors_names.len() {
-            0 => String::new(),
-            1 => new_authors_names.into_iter().next().unwrap(),
-            2 => new_authors_names.join(" and "),
-            _ => {
-                let fsts = new_authors_names[..new_authors_names.len() - 1].join(", ");
-                let last = new_authors_names.into_iter().last().unwrap();
-                [fsts, last].join(" and ")
+        let authors_list = match new_authors_names.as_slice() {
+            [] => String::new(),
+            [author] => author.clone(),
+            [fst, snd] => format!("{} and {}", fst, snd),
+            [fsts @ .., last] => {
+                let fsts = fsts.join(", ");
+                format!("{} and {}", fsts, last)
             }
         };
 
@@ -258,14 +257,13 @@ pub(crate) async fn delete(mut req: Request<State>) -> tide::Result {
         )
         .execute(conn)?;
 
-        let authors_list = match old_authors_names.len() {
-            0 => String::new(),
-            1 => old_authors_names.into_iter().next().unwrap(),
-            2 => old_authors_names.join(" and "),
-            _ => {
-                let fsts = old_authors_names[..old_authors_names.len() - 1].join(", ");
-                let last = old_authors_names.into_iter().last().unwrap();
-                [fsts, last].join(" and ")
+        let authors_list = match old_authors_names.as_slice() {
+            [] => String::new(),
+            [author] => author.clone(),
+            [fst, snd] => format!("{} and {}", fst, snd),
+            [fsts @ .., last] => {
+                let fsts = fsts.join(", ");
+                format!("{} and {}", fsts, last)
             }
         };
 

--- a/alexandrie/src/api/crates/owners.rs
+++ b/alexandrie/src/api/crates/owners.rs
@@ -159,7 +159,7 @@ pub(crate) async fn put(mut req: Request<State>) -> tide::Result {
         let authors_list = match new_authors_names.as_slice() {
             [] => String::new(),
             [author] => author.clone(),
-            [fst, snd] => format!("{} and {}", fst, snd),
+            [fst, snd] => format!("{}, and {}", fst, snd),
             [fsts @ .., last] => {
                 let fsts = fsts.join(", ");
                 format!("{} and {}", fsts, last)
@@ -260,7 +260,7 @@ pub(crate) async fn delete(mut req: Request<State>) -> tide::Result {
         let authors_list = match old_authors_names.as_slice() {
             [] => String::new(),
             [author] => author.clone(),
-            [fst, snd] => format!("{} and {}", fst, snd),
+            [fst, snd] => format!("{}, and {}", fst, snd),
             [fsts @ .., last] => {
                 let fsts = fsts.join(", ");
                 format!("{} and {}", fsts, last)


### PR DESCRIPTION
This PR refactors some code we had to make use of slice patterns to achieve clearer code that better communicates what it's actually doing than its initial implementation.  
[**Slice patterns**](https://blog.rust-lang.org/2020/03/12/Rust-1.42.html#subslice-patterns) is a stable feature of Rust since 1.42.  
Since Tide currently makes use of the `matches!(...)` macro (which was also added in 1.42), this change does not change our MSRV (although I am not sure what that version even is for Alexandrie, currently).