### PR TITLE
Re-organized code for setting up the server routes

### DIFF
--- a/alexandrie/src/api/crates/download.rs
+++ b/alexandrie/src/api/crates/download.rs
@@ -2,6 +2,7 @@ use async_std::io;
 
 use diesel::prelude::*;
 use semver::Version;
+use tide::http::mime;
 use tide::{Body, Request, Response, StatusCode};
 
 use alexandrie_storage::Store;
@@ -41,7 +42,7 @@ pub(crate) async fn get(req: Request<State>) -> tide::Result {
             let mut buf = Vec::new();
             krate.read_to_end(&mut buf)?;
             let mut response = Response::new(StatusCode::Ok);
-            response.insert_header("content-type", "application/octet-stream");
+            response.set_content_type(mime::BYTE_STREAM);
             response.set_body(Body::from_reader(io::Cursor::new(buf), None));
             Ok(response)
         } else {

--- a/alexandrie/src/config/frontend.rs
+++ b/alexandrie/src/config/frontend.rs
@@ -1,3 +1,5 @@
+use std::path::PathBuf;
+
 use handlebars::Handlebars;
 use serde::{Deserialize, Serialize};
 
@@ -18,14 +20,14 @@ pub struct Link {
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct AssetsConfig {
     /// Assets directory path.
-    pub path: String,
+    pub path: PathBuf,
 }
 
 /// The templates configuration options struct.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct TemplatesConfig {
     /// Templates directory path.
-    pub path: String,
+    pub path: PathBuf,
 }
 
 /// The frontend configuration struct.

--- a/alexandrie/src/main.rs
+++ b/alexandrie/src/main.rs
@@ -27,10 +27,17 @@ extern crate slog;
 
 use std::sync::Arc;
 
+#[cfg(feature = "frontend")]
+use std::io;
+#[cfg(feature = "frontend")]
+use std::path::PathBuf;
+
 use async_std::fs;
 
+use clap::{App, Arg};
+use tide::http::mime;
 use tide::utils::After;
-use tide::Response;
+use tide::{Body, Response, Server};
 
 /// API endpoints definitions.
 pub mod api;
@@ -52,7 +59,6 @@ pub mod frontend;
 use crate::config::Config;
 use crate::error::Error;
 use crate::utils::request_log::RequestLogger;
-use clap::{App, Arg};
 
 #[cfg(feature = "frontend")]
 use crate::utils::auth::AuthMiddleware;
@@ -72,10 +78,120 @@ embed_migrations!("../migrations/sqlite");
 #[cfg(feature = "postgres")]
 embed_migrations!("../migrations/postgres");
 
-#[allow(clippy::cognitive_complexity)]
+#[cfg(feature = "frontend")]
+fn frontend_routes(state: State, assets_path: PathBuf) -> io::Result<Server<State>> {
+    let mut app = tide::with_state(Arc::clone(&state));
+
+    info!("setting up cookie middleware");
+    app.middleware(CookiesMiddleware::new());
+    info!("setting up authentication middleware");
+    app.middleware(AuthMiddleware::new());
+
+    info!("mounting '/'");
+    app.at("/").get(frontend::index::get);
+    info!("mounting '/me'");
+    app.at("/me").get(frontend::me::get);
+    info!("mounting '/search'");
+    app.at("/search").get(frontend::search::get);
+    info!("mounting '/most-downloaded'");
+    app.at("/most-downloaded")
+        .get(frontend::most_downloaded::get);
+    info!("mounting '/last-updated'");
+    app.at("/last-updated").get(frontend::last_updated::get);
+    info!("mounting '/crates/:crate'");
+    app.at("/crates/:crate").get(frontend::krate::get);
+
+    info!("mounting '/account/login'");
+    app.at("/account/login")
+        .get(frontend::account::login::get)
+        .post(frontend::account::login::post);
+    info!("mounting '/account/logout'");
+    app.at("/account/logout")
+        .get(frontend::account::logout::get);
+    info!("mounting '/account/register'");
+    app.at("/account/register")
+        .get(frontend::account::register::get)
+        .post(frontend::account::register::post);
+    info!("mounting '/account/manage'");
+    app.at("/account/manage")
+        .get(frontend::account::manage::get);
+    info!("mounting '/account/manage/password'");
+    app.at("/account/manage/password")
+        .post(frontend::account::manage::passwd::post);
+    info!("mounting '/account/manage/tokens'");
+    app.at("/account/manage/tokens")
+        .post(frontend::account::manage::tokens::post);
+    info!("mounting '/account/manage/tokens/:token-id/revoke'");
+    app.at("/account/manage/tokens/:token-id/revoke")
+        .get(frontend::account::manage::tokens::revoke::get);
+
+    info!("mounting '/assets/*path'");
+    app.at("/assets").serve_dir(assets_path)?;
+
+    Ok(app)
+}
+
+fn api_routes(state: State) -> Server<State> {
+    let mut app = tide::with_state(state);
+
+    // Transform endpoint errors into the format expected by Cargo.
+    app.middleware(After(|mut res: Response| async {
+        if let Some(err) = res.error() {
+            let payload = json::json!({
+                "errors": [{
+                    "detail": err.to_string(),
+                }]
+            });
+            res.set_status(200);
+            res.set_content_type(mime::JSON);
+            res.set_body(Body::from_json(&payload)?);
+        }
+        Ok(res)
+    }));
+
+    info!("mounting '/api/v1/account/register'");
+    app.at("/account/register")
+        .post(api::account::register::post);
+    info!("mounting '/api/v1/account/login'");
+    app.at("/account/login").post(api::account::login::post);
+    info!("mounting '/api/v1/account/tokens'");
+    app.at("/account/tokens")
+        .post(api::account::token::info::post)
+        .put(api::account::token::generate::put)
+        .delete(api::account::token::revoke::delete);
+    info!("mounting '/api/v1/account/tokens/:name'");
+    app.at("/account/tokens/:name")
+        .get(api::account::token::info::get);
+    info!("mounting '/api/v1/categories'");
+    app.at("/categories").get(api::categories::get);
+    info!("mounting '/api/v1/crates'");
+    app.at("/crates").get(api::crates::search::get);
+    info!("mounting '/api/v1/crates/new'");
+    app.at("/crates/new").put(api::crates::publish::put);
+    info!("mounting '/api/v1/crates/suggest'");
+    app.at("/crates/suggest").get(api::crates::suggest::get);
+    info!("mounting '/api/v1/crates/:name'");
+    app.at("/crates/:name").get(api::crates::info::get);
+    info!("mounting '/api/v1/crates/:name/owners'");
+    app.at("/crates/:name/owners")
+        .get(api::crates::owners::get)
+        .put(api::crates::owners::put)
+        .delete(api::crates::owners::delete);
+    info!("mounting '/api/v1/crates/:name/:version/yank'");
+    app.at("/crates/:name/:version/yank")
+        .delete(api::crates::yank::delete);
+    info!("mounting '/api/v1/crates/:name/:version/unyank'");
+    app.at("/crates/:name/:version/unyank")
+        .put(api::crates::unyank::put);
+    info!("mounting '/api/v1/crates/:name/:version/download'");
+    app.at("/crates/:name/:version/download")
+        .get(api::crates::download::get);
+
+    app
+}
+
 async fn run() -> Result<(), Error> {
     let matches = App::new("alexandrie")
-        .version(version().as_str())
         .arg(
             Arg::with_name("config")
                 .short("c")
@@ -95,124 +211,24 @@ async fn run() -> Result<(), Error> {
     let frontend_enabled = config.frontend.enabled;
     #[cfg(feature = "frontend")]
     let assets_path = config.frontend.assets.path.clone();
-    let state: config::State = config.into();
+    let state: Arc<config::State> = Arc::new(config.into());
 
     info!("running database migrations");
-
     #[rustfmt::skip]
     state.repo.run(|conn| embedded_migrations::run(conn)).await
         .expect("migration execution error");
 
-    let mut app = tide::with_state(Arc::new(state));
+    let mut app = tide::with_state(Arc::clone(&state));
 
     info!("setting up request logger middleware");
     app.middleware(RequestLogger::new());
 
-    //handle when response error,set error message into body.
-    app.middleware(After(|mut res: Response| async {
-        if let Some(err) = res.error() {
-            let payload = json::json!({
-                "errors": [{
-                    "detail": err.to_string(),
-                }]
-            });
-            res.set_status(200);
-            res.set_content_type(tide::http::mime::JSON);
-            res.set_body(tide::Body::from_json(&payload)?);
-        }
-        Ok(res)
-    }));
-
     #[cfg(feature = "frontend")]
-    {
-        if frontend_enabled {
-            info!("setting up cookie middleware");
-            app.middleware(CookiesMiddleware::new());
-            info!("setting up authentication middleware");
-            app.middleware(AuthMiddleware::new());
-
-            info!("mounting '/'");
-            app.at("/").get(frontend::index::get);
-            info!("mounting '/me'");
-            app.at("/me").get(frontend::me::get);
-            info!("mounting '/search'");
-            app.at("/search").get(frontend::search::get);
-            info!("mounting '/most-downloaded'");
-            app.at("/most-downloaded")
-                .get(frontend::most_downloaded::get);
-            info!("mounting '/last-updated'");
-            app.at("/last-updated").get(frontend::last_updated::get);
-            info!("mounting '/crates/:crate'");
-            app.at("/crates/:crate").get(frontend::krate::get);
-
-            info!("mounting '/account/login'");
-            app.at("/account/login")
-                .get(frontend::account::login::get)
-                .post(frontend::account::login::post);
-            info!("mounting '/account/logout'");
-            app.at("/account/logout")
-                .get(frontend::account::logout::get);
-            info!("mounting '/account/register'");
-            app.at("/account/register")
-                .get(frontend::account::register::get)
-                .post(frontend::account::register::post);
-            info!("mounting '/account/manage'");
-            app.at("/account/manage")
-                .get(frontend::account::manage::get);
-            info!("mounting '/account/manage/password'");
-            app.at("/account/manage/password")
-                .post(frontend::account::manage::passwd::post);
-            info!("mounting '/account/manage/tokens'");
-            app.at("/account/manage/tokens")
-                .post(frontend::account::manage::tokens::post);
-            info!("mounting '/account/manage/tokens/:token-id/revoke'");
-            app.at("/account/manage/tokens/:token-id/revoke")
-                .get(frontend::account::manage::tokens::revoke::get);
-
-            info!("mounting '/assets/*path'");
-            app.at("/assets").serve_dir(assets_path)?;
-        }
+    if frontend_enabled {
+        let frontend = frontend_routes(Arc::clone(&state), assets_path)?;
+        app.at("/").nest(frontend);
     }
-
-    info!("mounting '/api/v1/account/register'");
-    app.at("/api/v1/account/register")
-        .post(api::account::register::post);
-    info!("mounting '/api/v1/account/login'");
-    app.at("/api/v1/account/login")
-        .post(api::account::login::post);
-    info!("mounting '/api/v1/account/tokens'");
-    app.at("/api/v1/account/tokens")
-        .post(api::account::token::info::post)
-        .put(api::account::token::generate::put)
-        .delete(api::account::token::revoke::delete);
-    info!("mounting '/api/v1/account/tokens/:name'");
-    app.at("/api/v1/account/tokens/:name")
-        .get(api::account::token::info::get);
-    info!("mounting '/api/v1/categories'");
-    app.at("/api/v1/categories").get(api::categories::get);
-    info!("mounting '/api/v1/crates'");
-    app.at("/api/v1/crates").get(api::crates::search::get);
-    info!("mounting '/api/v1/crates/new'");
-    app.at("/api/v1/crates/new").put(api::crates::publish::put);
-    info!("mounting '/api/v1/crates/suggest'");
-    app.at("/api/v1/crates/suggest")
-        .get(api::crates::suggest::get);
-    info!("mounting '/api/v1/crates/:name'");
-    app.at("/api/v1/crates/:name").get(api::crates::info::get);
-    info!("mounting '/api/v1/crates/:name/owners'");
-    app.at("/api/v1/crates/:name/owners")
-        .get(api::crates::owners::get)
-        .put(api::crates::owners::put)
-        .delete(api::crates::owners::delete);
-    info!("mounting '/api/v1/crates/:name/:version/yank'");
-    app.at("/api/v1/crates/:name/:version/yank")
-        .delete(api::crates::yank::delete);
-    info!("mounting '/api/v1/crates/:name/:version/unyank'");
-    app.at("/api/v1/crates/:name/:version/unyank")
-        .put(api::crates::unyank::put);
-    info!("mounting '/api/v1/crates/:name/:version/download'");
-    app.at("/api/v1/crates/:name/:version/download")
-        .get(api::crates::download::get);
+    app.at("/api/v1").nest(api_routes(state));
 
     info!("listening on '{0}'", addr);
     app.listen(addr).await?;

--- a/alexandrie/src/utils/request_log.rs
+++ b/alexandrie/src/utils/request_log.rs
@@ -1,3 +1,5 @@
+use std::time::Instant;
+
 use tide::utils::async_trait;
 use tide::{Middleware, Next, Request};
 
@@ -18,7 +20,7 @@ impl<State: Clone + Send + Sync + 'static> Middleware<State> for RequestLogger {
         let path = req.url().path().to_string();
         let method = req.method();
         info!("<-- {} {}", method, path);
-        let start = std::time::Instant::now();
+        let start = Instant::now();
         let res = next.run(req).await;
         let elapsed = start.elapsed().as_millis();
         let status = res.status();
@@ -26,7 +28,7 @@ impl<State: Clone + Send + Sync + 'static> Middleware<State> for RequestLogger {
             .error()
             .map(|err| err.to_string())
             .unwrap_or_else(|| "OK".to_string());
-        info!("--> {} {} {} {}ms , {}", method, path, status, elapsed, msg);
+        info!("--> {} {} {} {}ms, {}", method, path, status, elapsed, msg);
         Ok(res)
     }
 }

--- a/alexandrie/src/utils/response/mod.rs
+++ b/alexandrie/src/utils/response/mod.rs
@@ -1,5 +1,6 @@
 use json::json;
 use serde::Serialize;
+use tide::http::mime;
 use tide::{Body, Response, StatusCode};
 
 /// Various utilities to construct common response pages.
@@ -20,7 +21,7 @@ pub fn html(body: String) -> Response {
 pub fn html_with_status(status: StatusCode, body: String) -> Response {
     let mut response = Response::new(status);
     response.set_body(Body::from_string(body));
-    response.insert_header("content-type", "text/html");
+    response.set_content_type(mime::HTML);
     response
 }
 


### PR DESCRIPTION
This PR refactors the server initialization code by separating frontend-related routes and API-related routes into separate `tide::Server` that are then simply nested into a common one.  

This change will also allow assigning different middlewares to each of them separately.
