### PR TITLE
Added canonicalization of crate names

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -66,7 +66,7 @@ COPY syntect /home/alex/syntect
 COPY templates /home/alex/templates
 COPY migrations /home/alex/migrations
 # copy diesel config
-COPY diesel.toml /home/alex/diesel.toml
+# COPY diesel.toml /home/alex/diesel.toml
 
 ARG USER_ID=1000
 ARG GROUP_ID=1000

--- a/crates/alexandrie/src/api/crates/info.rs
+++ b/crates/alexandrie/src/api/crates/info.rs
@@ -34,6 +34,8 @@ pub struct ResponseBody {
 pub async fn get(req: Request<State>) -> tide::Result {
     let name = req.param("name")?.to_string();
 
+    let name = utils::canonical_name(name);
+
     let state = req.state().clone();
     let repo = &state.repo;
 
@@ -41,7 +43,7 @@ pub async fn get(req: Request<State>) -> tide::Result {
     let krate = repo
         .run(move |conn| {
             crates::table
-                .filter(crates::name.eq(name.as_str()))
+                .filter(crates::canon_name.eq(name.as_str()))
                 .first::<Crate>(conn)
                 .optional()
         })

--- a/crates/alexandrie/src/api/crates/publish.rs
+++ b/crates/alexandrie/src/api/crates/publish.rs
@@ -206,6 +206,8 @@ pub(crate) async fn put(mut req: Request<State>) -> tide::Result {
     let transaction = repo.transaction(move |conn| {
         let state = req.state();
 
+        let canon_name = utils::canonical_name(metadata.name.as_str());
+
         //? Construct a crate description.
         let crate_desc = CrateVersion {
             name: metadata.name,
@@ -242,6 +244,7 @@ pub(crate) async fn put(mut req: Request<State>) -> tide::Result {
         let now = Utc::now().naive_utc().format(DATETIME_FORMAT).to_string();
         let new_crate = NewCrate {
             name: crate_desc.name.as_str(),
+            canon_name: canon_name.as_str(),
             description: metadata.description.as_deref(),
             documentation: metadata.documentation.as_deref(),
             repository: metadata.repository.as_deref(),
@@ -250,7 +253,7 @@ pub(crate) async fn put(mut req: Request<State>) -> tide::Result {
         };
 
         //? Does the crate already exists?
-        let exists = utils::checks::crate_exists(conn, new_crate.name)?;
+        let exists = utils::checks::crate_exists(conn, new_crate.canon_name)?;
 
         //? Are we adding a new crate or updating a new one?
         let operation = if exists {

--- a/crates/alexandrie/src/api/crates/suggest.rs
+++ b/crates/alexandrie/src/api/crates/suggest.rs
@@ -43,8 +43,10 @@ pub(crate) async fn get(req: Request<State>) -> tide::Result {
     //? Fetch the latest index changes.
     // state.index.refresh()?;
 
+    let name = utils::canonical_name(params.q);
+
     //? Build the search pattern.
-    let name_pattern = format!("%{0}%", params.q.replace('\\', "\\\\").replace('%', "\\%"));
+    let name_pattern = format!("%{0}%", name.replace('\\', "\\\\").replace('%', "\\%"));
 
     //? Limit the result count depending on parameters.
     let limit = params.limit.map_or(10, |limit| i64::from(limit.get()));
@@ -53,7 +55,7 @@ pub(crate) async fn get(req: Request<State>) -> tide::Result {
     let results = repo
         .run(move |conn| {
             crates::table
-                .filter(crates::name.like(name_pattern.as_str()))
+                .filter(crates::canon_name.like(name_pattern.as_str()))
                 .limit(limit)
                 .load::<Crate>(conn)
         })

--- a/crates/alexandrie/src/api/crates/unyank.rs
+++ b/crates/alexandrie/src/api/crates/unyank.rs
@@ -1,9 +1,11 @@
+use diesel::prelude::*;
 use json::json;
 use semver::Version;
 use tide::{Request, StatusCode};
 
 use alexandrie_index::Indexer;
 
+use crate::db::schema::crates;
 use crate::error::AlexError;
 use crate::utils;
 use crate::State;
@@ -11,6 +13,8 @@ use crate::State;
 pub(crate) async fn put(req: Request<State>) -> tide::Result {
     let name = req.param("name")?.to_string();
     let version: Version = req.param("version")?.parse()?;
+
+    let name = utils::canonical_name(name);
 
     let state = req.state().clone();
     let repo = &state.repo;
@@ -40,6 +44,12 @@ pub(crate) async fn put(req: Request<State>) -> tide::Result {
                 "you are not an author of this crate",
             ));
         }
+
+        //? Get the non-canonical crate name from the canonical one.
+        let name = crates::table
+            .select(crates::name)
+            .filter(crates::canon_name.eq(name.as_str()))
+            .first::<String>(conn)?;
 
         state.index.unyank_record(name.as_str(), version.clone())?;
 

--- a/crates/alexandrie/src/api/crates/yank.rs
+++ b/crates/alexandrie/src/api/crates/yank.rs
@@ -1,9 +1,11 @@
+use diesel::prelude::*;
 use json::json;
 use semver::Version;
 use tide::{Request, StatusCode};
 
 use alexandrie_index::Indexer;
 
+use crate::db::schema::crates;
 use crate::error::AlexError;
 use crate::utils;
 use crate::State;
@@ -11,6 +13,8 @@ use crate::State;
 pub(crate) async fn delete(req: Request<State>) -> tide::Result {
     let name = req.param("name")?.to_string();
     let version: Version = req.param("version")?.parse()?;
+
+    let name = utils::canonical_name(name);
 
     let state = req.state().clone();
     let repo = &state.repo;
@@ -41,6 +45,12 @@ pub(crate) async fn delete(req: Request<State>) -> tide::Result {
                 "you are not an author of this crate",
             ));
         }
+
+        //? Get the non-canonical crate name from the canonical one.
+        let name = crates::table
+            .select(crates::name)
+            .filter(crates::canon_name.eq(name.as_str()))
+            .first::<String>(conn)?;
 
         state.index.yank_record(name.as_str(), version.clone())?;
 

--- a/crates/alexandrie/src/config/mod.rs
+++ b/crates/alexandrie/src/config/mod.rs
@@ -25,6 +25,8 @@ pub use crate::config::frontend::*;
 pub struct GeneralConfig {
     /// The address to bind the server on.
     pub bind_address: String,
+    /// The maximum size of crates.
+    pub max_payload_size: usize,
 }
 
 /// The application configuration struct.

--- a/crates/alexandrie/src/config/mod.rs
+++ b/crates/alexandrie/src/config/mod.rs
@@ -25,8 +25,6 @@ pub use crate::config::frontend::*;
 pub struct GeneralConfig {
     /// The address to bind the server on.
     pub bind_address: String,
-    /// The maximum size of crates.
-    pub max_payload_size: usize,
 }
 
 /// The application configuration struct.

--- a/crates/alexandrie/src/db/models.rs
+++ b/crates/alexandrie/src/db/models.rs
@@ -21,6 +21,8 @@ pub struct Crate {
     pub id: i64,
     /// The crate's name.
     pub name: String,
+    /// The crate's canonical name ('-' are all replaced with '_').
+    pub canon_name: String,
     /// The crate's description.
     pub description: Option<String>,
     /// The crate's creation date.
@@ -42,6 +44,8 @@ pub struct Crate {
 pub struct NewCrate<'a> {
     /// The crate's name.
     pub name: &'a str,
+    /// The crate's canonical name ('-' are all replaced with '_').
+    pub canon_name: &'a str,
     /// The crate's description.
     pub description: Option<&'a str>,
     /// The crate's creation date.

--- a/crates/alexandrie/src/db/schema.rs
+++ b/crates/alexandrie/src/db/schema.rs
@@ -19,6 +19,8 @@ table! {
         id -> Bigint,
         /// The crate's name.
         name -> Varchar,
+        /// The crate's canonical name ('-' are all replaced with '_').
+        canon_name -> Varchar,
         /// The crate's descripton.
         description -> Nullable<Varchar>,
         /// The crate's creation date.

--- a/crates/alexandrie/src/frontend/krate.rs
+++ b/crates/alexandrie/src/frontend/krate.rs
@@ -24,6 +24,8 @@ struct BadgeRepr {
 pub(crate) async fn get(req: Request<State>) -> tide::Result {
     let name = req.param("crate")?.to_string();
 
+    let canon_name = utils::canonical_name(name);
+
     let user = req.get_author();
     let state = req.state().clone();
     let repo = &state.repo;
@@ -33,7 +35,7 @@ pub(crate) async fn get(req: Request<State>) -> tide::Result {
 
         //? Get this crate's data.
         let crate_desc = crates::table
-            .filter(crates::name.eq(&name))
+            .filter(crates::canon_name.eq(canon_name.as_str()))
             .first::<Crate>(conn)
             .optional()?;
         let crate_desc = match crate_desc {
@@ -43,7 +45,7 @@ pub(crate) async fn get(req: Request<State>) -> tide::Result {
                     state.as_ref(),
                     user,
                     StatusCode::NotFound,
-                    format!("No crate named '{0}' has been found.", name),
+                    format!("No crate named '{0}' has been found.", canon_name),
                 );
             }
         };

--- a/crates/alexandrie/src/frontend/search.rs
+++ b/crates/alexandrie/src/frontend/search.rs
@@ -26,7 +26,10 @@ struct SearchParams {
 pub(crate) async fn get(req: Request<State>) -> tide::Result {
     let params = req.query::<SearchParams>()?;
     let searched_text = utils::canonical_name(params.q.as_str());
-    let q = format!("%{0}%", searched_text.replace('\\', "\\\\").replace('%', "\\%"));
+    let q = format!(
+        "%{0}%",
+        searched_text.replace('\\', "\\\\").replace('%', "\\%")
+    );
 
     let page_number = params.page.map_or_else(|| 1, |page| page.get());
 

--- a/crates/alexandrie/src/frontend/search.rs
+++ b/crates/alexandrie/src/frontend/search.rs
@@ -25,8 +25,9 @@ struct SearchParams {
 
 pub(crate) async fn get(req: Request<State>) -> tide::Result {
     let params = req.query::<SearchParams>()?;
-    let searched_text = params.q.clone();
-    let q = format!("%{0}%", params.q.replace('\\', "\\\\").replace('%', "\\%"));
+    let searched_text = utils::canonical_name(params.q.as_str());
+    let q = format!("%{0}%", searched_text.replace('\\', "\\\\").replace('%', "\\%"));
+
     let page_number = params.page.map_or_else(|| 1, |page| page.get());
 
     let user = req.get_author();
@@ -39,12 +40,12 @@ pub(crate) async fn get(req: Request<State>) -> tide::Result {
         //? Get the total count of search results.
         let total_results = crates::table
             .select(sql::count(crates::id))
-            .filter(crates::name.like(q.as_str()))
+            .filter(crates::canon_name.like(q.as_str()))
             .first::<i64>(conn)?;
 
         //? Get the search results for the given page number.
         let results: Vec<Crate> = crates::table
-            .filter(crates::name.like(q.as_str()))
+            .filter(crates::canon_name.like(q.as_str()))
             .limit(15)
             .offset(15 * i64::from(page_number - 1))
             .load(conn)?;
@@ -88,7 +89,7 @@ pub(crate) async fn get(req: Request<State>) -> tide::Result {
         let context = json!({
             "user": user,
             "instance": &state.frontend.config,
-            "searched_text": searched_text,
+            "searched_text": params.q,
             "total_results": total_results,
             "pagination": {
                 "current": page_number,

--- a/crates/alexandrie/src/utils/checks.rs
+++ b/crates/alexandrie/src/utils/checks.rs
@@ -7,20 +7,26 @@ use crate::db::Connection;
 use crate::error::Error;
 
 /// Checks if a crate exists in the database given a connection and the crate's name.
-pub fn crate_exists(conn: &Connection, name: &str) -> Result<bool, Error> {
-    let exists: bool =
-        sql::select(sql::exists(crates::table.filter(crates::name.eq(name)))).get_result(conn)?;
+pub fn crate_exists(conn: &Connection, canon_name: &str) -> Result<bool, Error> {
+    let exists: bool = sql::select(sql::exists(
+        crates::table.filter(crates::canon_name.eq(canon_name)),
+    ))
+    .get_result(conn)?;
 
     Ok(exists)
 }
 
 /// Checks if a user is an author of the named crate.
-pub fn is_crate_author(conn: &Connection, crate_name: &str, author_id: i64) -> Result<bool, Error> {
+pub fn is_crate_author(
+    conn: &Connection,
+    canon_crate_name: &str,
+    author_id: i64,
+) -> Result<bool, Error> {
     let exists: bool = sql::select(sql::exists(
         crate_authors::table
             .inner_join(authors::table)
             .inner_join(crates::table)
-            .filter(crates::name.eq(crate_name))
+            .filter(crates::canon_name.eq(canon_crate_name))
             .filter(authors::id.eq(author_id)),
     ))
     .get_result(conn)?;

--- a/crates/alexandrie/src/utils/mod.rs
+++ b/crates/alexandrie/src/utils/mod.rs
@@ -22,5 +22,5 @@ pub mod flash;
 /// been replaced by underscores ('_') for consistency, because
 /// they are considered to be equivalent.
 pub fn canonical_name(name: impl AsRef<str>) -> String {
-    name.as_ref().replace("-", "_")
+    name.as_ref().to_ascii_lowercase().replace("-", "_")
 }

--- a/crates/alexandrie/src/utils/mod.rs
+++ b/crates/alexandrie/src/utils/mod.rs
@@ -15,3 +15,12 @@ pub mod cookies;
 /// Utilities for using flash cookies.
 #[cfg(feature = "frontend")]
 pub mod flash;
+
+/// Transforms a crate name to its canonical form.
+///
+/// A canonical crate name means that all dashes ('-') have
+/// been replaced by underscores ('_') for consistency, because
+/// they are considered to be equivalent.
+pub fn canonical_name(name: impl AsRef<str>) -> String {
+    name.as_ref().replace("-", "_")
+}

--- a/diesel.toml
+++ b/diesel.toml
@@ -1,3 +1,0 @@
-[print_schema]
-file = "src/db/schema.rs"
-with_docs = true

--- a/docs/src/whats-available/docker.md
+++ b/docs/src/whats-available/docker.md
@@ -1,47 +1,48 @@
-# Running Alexandrie with Docker
+Running Alexandrie with Docker
+==============================
 
 Alexandrie can be run in a Docker container, which can make it easier to start, stop, and build on a non-Linux system.
 
-
-## Dependencies
+Dependencies
+------------
 
 To run Alexandrie in docker, you'll need:
 
-* The `Alexandrie` source pulled from GitHub
-* [docker](https://docs.docker.com/install/)
-* [docker-compose](https://docs.docker.com/compose/install/)
+- The `Alexandrie` source code pulled from GitHub
+- [docker](https://docs.docker.com/install/)
+- [docker-compose](https://docs.docker.com/compose/install/)
 
 Make sure that `docker` and `docker-compose` are in your system path.
 
-
-## User Configuration
+User Configuration
+------------------
 
 A small bit of setup is required before you can start the docker containers. First, copy `example.env` to `.env` (the filename is important, don't prefix the extension), and modify the values inside:
 
-* Create a new, empty directory where the application can create data, and then set `APPDATA` to the absolute path to that folder.
-* Set `CRATE_INDEX` to the SSH path of an existing git repository with a valid index `config.json` file.
-* Set `GIT_NAME` and `GIT_EMAIL` to valid git values that will be used when Alexandrie commits & pushes those commits to the index.
-* Set `GIT_SSH_KEY` to a new or existing passwordless SSH key. The `.pub` key associated with this key should be added to github/gitlab/etc. to grant access to clone and push the crate index.
-
+- Create a new, empty directory where the application can create data, and then set `APPDATA` to the absolute path to that folder.
+- Set `CRATE_INDEX` to the SSH path of an existing git repository with a valid index `config.json` file.
+- Set `GIT_NAME` and `GIT_EMAIL` to valid git values that will be used when Alexandrie commits & pushes those commits to the index.
+- Set `GIT_SSH_KEY` to a new or existing passwordless SSH key. The `.pub` key associated with this key should be added to github/gitlab/etc. to grant access to clone and push the crate index.
 
 By default Alexandrie will use SQLite. If you want to use either MySQL or PostgreSQL instead, you'll need to create a file at either `docker/mysql/rootpass.txt` or `docker/postgres/rootpass.txt` which contains the password that will be given to the root user of the database.
-
 
 ### Additional Configuration
 
 If necessary, `alexandrie.toml` and even `diesel.toml` can still be modified, and the docker images can be configured to use those modified files instead. You should read the [Internals](#internals) section first, and will likely need to already have docker knowledge. Some other config files and scripts will need to be modified if you change Alexandrie's port or appdata mount location, for example.
 
-You can also defined the environment variables `USER_ID` and `GROUP_ID` to specify the UID and GID of the alex user created in the web container.
+You can also define the environment variables `USER_ID` and `GROUP_ID` to specify the UID and GID of the `alex` user created in the web container.
 
-## Usage
+Usage
+-----
 
 ### Running
 
 To run, you can use the `run_docker.sh` script for easy setup or teardown. See `run_docker.sh --help` for a list of options.
 
-By default, Alexandrie will use SQLite and run in the background. 
+By default, Alexandrie will use SQLite and run in the background.
 
-**Bringup**
+**Bringup:**
+
 ```bash
 ./run_docker.sh up
 ```
@@ -54,12 +55,12 @@ If you want to use MySQL and run in the foreground, here's an example:
 
 If you run in the foreground and kill the services with `Ctrl+C`, the docker containers will stop, but you still may need to run [teardown](#stopping-and-cleanup) for the containers to be deleted fully.
 
-
 ### Stopping and Cleanup
 
 Stopping Alexandrie is as easy as starting it.
 
-**Teardown**
+**Teardown:**
+
 ```bash
 ./run_docker.sh down
 ```
@@ -72,32 +73,28 @@ To stop, for example, a MySQL setup for Alexandrie, run the following:
 
 If you're not planning on running Alexandrie again or want to do a full clean of the environment, you can disassociate your local appdata storage from the docker volume database by doing `docker volume prune`, which will delete all unused volumes.
 
-
 ### Next Steps
 
 As Alexandrie will (by default) serve on port `3000` (and directly setting that to port `80` will likely not work for a non-root user and won't allow https), the recommended way to serve the application would be to install & configure `nginx` or another ingress controller.
 
-
-## Internals
+Internals
+---------
 
 The `run_docker` script is using `docker-compose` under the hood, which is itself just `docker` instrumentation. `docker-compose` is configured for this project through a few files:
 
-* `.env`: contains variables that can be changed by the user for easy configuration
-* `docker-compose.yaml`: basic setup for docker images, volumes, etc.; should rarely be touched by the user
-* `docker/<database>/<database>-compose.yaml`: supplemental and database-dependent; should rarely be touched by the user
+- `.env`: contains variables that can be changed by the user for easy configuration
+- `docker-compose.yaml`: basic setup for docker images, volumes, etc.; should rarely be touched by the user
+- `docker/<database>/<database>-compose.yaml`: supplemental and database-dependent; should rarely be touched by the user
 
 Some additional files are responsible for actually creating the Docker image for Alexandrie, as well as handling starting the application, database, etc.:
 
-* `Dockerfile`: definition for creating the Docker image for Alexandrie itself
-* `docker/startup.sh`: ran inside the Docker image to do first-run database initialization with diesel, ssh & git configuration, and start Alexandrie
-* `docker/<database>/alexandrie.toml`: application configuration, which has database-dependent features
-
+- `Dockerfile`: definition for creating the Docker image for Alexandrie itself
+- `docker/startup.sh`: ran inside the Docker image to do first-run database initialization with diesel, ssh & git configuration, and start Alexandrie
+- `docker/<database>/alexandrie.toml`: application configuration, which has database-dependent features
 
 Modifying `alexandrie.toml` may require additional modification of some of these files, for example if the port is modified.
 
-
 It's worth mentioning that the Docker image will copy the Alexandrie source contained in the local directory, a.k.a. the source isn't pulled down from the git repo when building the image. If you modifiy the source code, those modifications can be used to make the image for testing, etc.
-
 
 ### Example Run
 
@@ -109,15 +106,15 @@ docker-compose -f docker-compose.yaml -f docker/mysql/mysql-compose.yaml up
 ```
 
 This will use all of the following files, in addition to the Alexandrie source code:
-* `docker-compose.yaml`
-* `.env`
-* `diesel.toml`
-* `Dockerfile`
-* `docker/startup.sh`
-* `docker/mysql/mysql-compose.yaml`
-* `docker/mysql/alexandrie.toml`
-* `docker/mysql/rootpass.txt`
 
+- `docker-compose.yaml`
+- `.env`
+- `diesel.toml`
+- `Dockerfile`
+- `docker/startup.sh`
+- `docker/mysql/mysql-compose.yaml`
+- `docker/mysql/alexandrie.toml`
+- `docker/mysql/rootpass.txt`
 
 ### Database
 

--- a/migrations/mysql/2020-08-07-205435_canonical-names/down.sql
+++ b/migrations/mysql/2020-08-07-205435_canonical-names/down.sql
@@ -1,0 +1,1 @@
+alter table crates drop column canon_name;

--- a/migrations/mysql/2020-08-07-205435_canonical-names/up.sql
+++ b/migrations/mysql/2020-08-07-205435_canonical-names/up.sql
@@ -1,4 +1,4 @@
 alter table crates add column canon_name varchar(255);
-update crates set canon_name = replace(name, '-', '_');
+update crates set name = lower(name), canon_name = replace(lower(name), '-', '_');
 alter table crates modify canon_name varchar(255) not null;
 alter table crates add unique (canon_name);

--- a/migrations/mysql/2020-08-07-205435_canonical-names/up.sql
+++ b/migrations/mysql/2020-08-07-205435_canonical-names/up.sql
@@ -1,0 +1,4 @@
+alter table crates add column canon_name varchar(255);
+update crates set canon_name = replace(name, "-", "_");
+alter table crates modify canon_name varchar(255) not null;
+alter table crates add unique (canon_name);

--- a/migrations/mysql/2020-08-07-205435_canonical-names/up.sql
+++ b/migrations/mysql/2020-08-07-205435_canonical-names/up.sql
@@ -1,4 +1,4 @@
 alter table crates add column canon_name varchar(255);
-update crates set canon_name = replace(name, "-", "_");
+update crates set canon_name = replace(name, '-', '_');
 alter table crates modify canon_name varchar(255) not null;
 alter table crates add unique (canon_name);

--- a/migrations/postgres/2020-08-07-205435_canonical-names/down.sql
+++ b/migrations/postgres/2020-08-07-205435_canonical-names/down.sql
@@ -1,0 +1,1 @@
+alter table crates drop column canon_name;

--- a/migrations/postgres/2020-08-07-205435_canonical-names/up.sql
+++ b/migrations/postgres/2020-08-07-205435_canonical-names/up.sql
@@ -1,4 +1,4 @@
 alter table crates add column canon_name varchar(255);
-update crates set canon_name = replace(name, '-', '_');
+update crates set name = lower(name), canon_name = replace(lower(name), '-', '_');
 alter table crates alter column canon_name set not null;
 alter table crates add unique (canon_name);

--- a/migrations/postgres/2020-08-07-205435_canonical-names/up.sql
+++ b/migrations/postgres/2020-08-07-205435_canonical-names/up.sql
@@ -1,0 +1,4 @@
+alter table crates add column canon_name varchar(255);
+update crates set canon_name = replace(name, "-", "_");
+alter table crates modify canon_name varchar(255) not null;
+alter table crates add unique (canon_name);

--- a/migrations/postgres/2020-08-07-205435_canonical-names/up.sql
+++ b/migrations/postgres/2020-08-07-205435_canonical-names/up.sql
@@ -1,4 +1,4 @@
 alter table crates add column canon_name varchar(255);
-update crates set canon_name = replace(name, "-", "_");
-alter table crates modify canon_name varchar(255) not null;
+update crates set canon_name = replace(name, '-', '_');
+alter table crates alter column canon_name set not null;
 alter table crates add unique (canon_name);

--- a/migrations/sqlite/2020-08-07-205435_canonical-names/down.sql
+++ b/migrations/sqlite/2020-08-07-205435_canonical-names/down.sql
@@ -1,0 +1,14 @@
+alter table crates rename to crates_old;
+create table crates (
+    id integer primary key,
+    name varchar(255) not null unique,
+    description varchar(4096),
+    created_at varchar(25) not null,
+    updated_at varchar(25) not null,
+    downloads bigint not null default 0,
+    documentation varchar(1024),
+    repository varchar(1024)
+);
+insert into crates (id, name, description, created_at, updated_at, downloads, documentation, repository)
+    select id, name, description, created_at, updated_at, downloads, documentation, repository from crates_old;
+drop table crates_old;

--- a/migrations/sqlite/2020-08-07-205435_canonical-names/up.sql
+++ b/migrations/sqlite/2020-08-07-205435_canonical-names/up.sql
@@ -11,5 +11,5 @@ create table crates (
     repository varchar(1024)
 );
 insert into crates (id, name, canon_name, description, created_at, updated_at, downloads, documentation, repository)
-    select id, name, replace(name, '-', '_'), description, created_at, updated_at, downloads, documentation, repository from crates_old;
+    select id, lower(name), replace(lower(name), '-', '_'), description, created_at, updated_at, downloads, documentation, repository from crates_old;
 drop table crates_old;

--- a/migrations/sqlite/2020-08-07-205435_canonical-names/up.sql
+++ b/migrations/sqlite/2020-08-07-205435_canonical-names/up.sql
@@ -11,5 +11,5 @@ create table crates (
     repository varchar(1024)
 );
 insert into crates (id, name, canon_name, description, created_at, updated_at, downloads, documentation, repository)
-    select id, name, replace(name, "-", "_"), description, created_at, updated_at, downloads, documentation, repository from crates_old;
+    select id, name, replace(name, '-', '_'), description, created_at, updated_at, downloads, documentation, repository from crates_old;
 drop table crates_old;

--- a/migrations/sqlite/2020-08-07-205435_canonical-names/up.sql
+++ b/migrations/sqlite/2020-08-07-205435_canonical-names/up.sql
@@ -1,0 +1,15 @@
+alter table crates rename to crates_old;
+create table crates (
+    id integer primary key,
+    name varchar(255) not null unique,
+    canon_name varchar(255) not null unique, -- <- NEW FIELD
+    description varchar(4096),
+    created_at varchar(25) not null,
+    updated_at varchar(25) not null,
+    downloads bigint not null default 0,
+    documentation varchar(1024),
+    repository varchar(1024)
+);
+insert into crates (id, name, canon_name, description, created_at, updated_at, downloads, documentation, repository)
+    select id, name, replace(name, "-", "_"), description, created_at, updated_at, downloads, documentation, repository from crates_old;
+drop table crates_old;


### PR DESCRIPTION
This PR changes how the registry looks for crates by name, to account for the fact that dashes (`-`) and underscores (`_`) are considered equivalent in crate names.  
This is a change that should have been done since the beginning, since it was previously possible to publish two different crates whose canonical names are the same.  

So, after this PR, you can get information about a crate named **`async-std`** by accessing either one of:
- **`/api/v1/crates/async-std`**
- **`/api/v1/crates/async_std`** (this one was previously denied)

This applies to every endpoint mentioning any crate by name, including the frontend-related ones.

**IMPORTANT NOTE:**  
This change requires a database schema change, implemented as a diesel migration for all 3 supported database vendors.  
Since migrations are automatically run on start-up, this change should be entirely transparent.  
The new canonical names are automatically derived from existing names, as part of the migration.  