### PR TITLE
Added S3 storage documentation in user guide

### DIFF
--- a/docs/src/whats-available/crate-stores.md
+++ b/docs/src/whats-available/crate-stores.md
@@ -4,12 +4,43 @@ Available crate stores
 'disk': Local on-disk store
 ---------------------------
 
-This store implements simple local storage of crates as files in a given directory.
+This strategy implements simple local storage of crates as files in a given directory.
 
-Here is an example of a configuration using this storage:
+Here is an example of configuration to use this storage strategy:
 
 ```toml
 [storage]
 type = "disk"           # required.
 path = "crate-storage"  # required: path of the directory in which to store the crates.
 ```
+
+'s3': AWS S3 object storage
+---------------------------
+
+This strategy stores crate archives and READMEs as objects within an AWS S3 bucket.
+
+Here is an example of configuration to use this storage strategy:
+
+```toml
+[storage]
+type = "s3"                     # required.
+region = ["eu-west-1"]          # required: name of the operating region of the S3 bucket.
+bucket = "eu-polomack-crates"   # required: name of the S3 bucket to use.
+key_prefix = "crates"           # optional: arbitrary prefix to apply on the objects' keys
+                                #           allowing to place them in subdirectories.
+```
+
+You can specify a custom S3 endpoint, instead of the official S3 ones, using the `region` key, like this:
+
+```toml
+region = ["custom", "https://my.custom.s3.endpoint/"]
+```
+
+### S3 Authentication
+
+In order to authenticate the registry to S3, you can either:
+
+- define both `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` environment variables when running the registry.
+- have credentials stored in `~/.aws/config` (called the 'profile') and giving the registry read permission to it.
+
+The environment method is prioritized over the profile method.

--- a/docs/src/whats-available/crate-stores.md
+++ b/docs/src/whats-available/crate-stores.md
@@ -41,6 +41,10 @@ region = ["custom", "https://my.custom.s3.endpoint/"]
 In order to authenticate the registry to S3, you can either:
 
 - define both `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` environment variables when running the registry.
-- have credentials stored in `~/.aws/config` (called the 'profile') and giving the registry read permission to it.
+- have a `credential_process` command specified in `~/.aws/config`.
+- have credentials stored in `~/.aws/credentials` and giving the registry read permission to it.
+- using an IAM instance profile, which will only work if running on an EC2 instance with an instance profile/role assigned.
 
-The environment method is prioritized over the profile method.
+These different options are attempted in that same order, whichever is found to have valid credentials first.
+
+> For more details on how authentication is resolved, you can refer to the Rusoto's documentation on that matter.

--- a/docs/src/whats-available/mod.md
+++ b/docs/src/whats-available/mod.md
@@ -12,8 +12,8 @@ As index management strategies, we have:
 As crate storage strategies, we have:
 
 - `disk`: local on-disk crate storage.
+- `s3`: crate storage within an AWS S3 bucket.
 - **(PLANNED)** `remote`: just like `disk`, but on a remote machine, managed by a companion server.
-- **(PLANNED)** `s3`: stores crates in an AWS S3 bucket.
 
 **PSA:**  
 The 'PLANNED' items are ideas that are possible to implement but no guarantees or deadline as to when they would actually land.  


### PR DESCRIPTION
This PR adds an entry in the user guide to document how to configure the newly-available S3 storage strategy, as well as how to authenticate the registry to S3.  