### PR TITLE
Make it possible to choose the UID/GID of the alex user

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -7,6 +7,8 @@ services:
       context: .
       args:
         - DATABASE=${DATABASE}
+        - GROUP_ID=${GROUP_ID}
+        - USER_ID=${USER_ID}
     # tag the image after it's built
     #        app / app version : docker image version (per app version)
     image: alexandrie-0.1.0-${DATABASE}:0.1

--- a/docs/src/whats-available/docker.md
+++ b/docs/src/whats-available/docker.md
@@ -31,6 +31,7 @@ By default Alexandrie will use SQLite. If you want to use either MySQL or Postgr
 
 If necessary, `alexandrie.toml` and even `diesel.toml` can still be modified, and the docker images can be configured to use those modified files instead. You should read the [Internals](#internals) section first, and will likely need to already have docker knowledge. Some other config files and scripts will need to be modified if you change Alexandrie's port or appdata mount location, for example.
 
+You can also defined the environment variables `USER_ID` and `GROUP_ID` to specify the UID and GID of the alex user created in the web container.
 
 ## Usage
 


### PR DESCRIPTION
Hello,

The UID and SIG set to [1000](https://github.com/Hirevo/alexandrie/blob/master/Dockerfile#L74) can conflict with a user existing on the host running the containers. It could be handy to have control over their value.

Since these settings are managed by some args parameters, we could use the same mechanism as for the `DATABASE` arg and replace this [block](https://github.com/Hirevo/alexandrie/blob/master/docker-compose.yaml#L8):

```
build:
  context: .
  args:
    - DATABASE=${DATABASE}
```

by

```
build:
  context: .
  args:
    - DATABASE=${DATABASE}
    - GROUP_ID=${GROUP_ID}
    - USER_ID=${USER_ID}
```

Thanks,
Hugo