### PR TITLE
Added helper binary to regenerate READMEs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2207,6 +2207,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "readme-render"
+version = "0.1.0"
+dependencies = [
+ "alexandrie-rendering",
+ "serde",
+ "toml",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.1.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,4 +5,5 @@ members = [
     "crates/alexandrie-storage",
     "crates/alexandrie-rendering",
     "helpers/syntect-dump",
+    "helpers/readme-render",
 ]

--- a/helpers/readme-render/Cargo.toml
+++ b/helpers/readme-render/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "readme-render"
+version = "0.1.0"
+edition = "2018"
+authors = ["Nicolas Polomack <nicolas@polomack.eu>"]
+description = "A simple helper to generate syntect's binary dumps for Alexandrie"
+repository = "https://github.com/Hirevo/alexandrie"
+documentation = "https://crates.polomack.eu/docs/alexandrie"
+license = "MIT OR Apache-2.0"
+publish = false
+
+[dependencies]
+alexandrie-rendering = { path = "../../crates/alexandrie-rendering", version = "0.1.0" }
+serde = { version = "1.0.124", features = ["derive"] }
+toml = "0.5.8"
+
+[features]

--- a/helpers/readme-render/src/main.rs
+++ b/helpers/readme-render/src/main.rs
@@ -1,0 +1,26 @@
+use std::fs;
+use std::env;
+
+use alexandrie_rendering::config::{SyntectConfig, SyntectState};
+
+use serde::{Serialize, Deserialize};
+
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+pub struct Config {
+    /// The syntax-highlighting configuration.
+    pub syntect: SyntectConfig,
+}
+
+fn main() {
+    let readme_path = env::args().skip(1).next().expect("could not find a command-line argument");
+
+    let contents = fs::read("alexandrie.toml").expect("could not open configuration file `alexandrie.toml`");
+    let config: Config = toml::from_slice(contents.as_slice()).expect("could not parse configuration file");
+
+    let state = SyntectState::from(config.syntect);
+
+    let contents = fs::read_to_string(readme_path).expect("could not open README file");
+    let rendered = alexandrie_rendering::render_readme(&state, &contents);
+
+    fs::write("output.html", &rendered).expect("could not write rendered HTML output");
+}


### PR DESCRIPTION
This PR adds a new helper binary to help (re)generate README (or any markdown file) with syntax-highlighted code blocks when needed.

It loads syntaxes and themes in the same way the main registry does it by depending on the same **`alexandrie-rendering`** crate and loading settings from the same config file.

An easy way to invoke it is simply to execute the following command at the repository root:

```bash
cargo run -p readme-render
```