### PR TITLE
Include 's3' feature doc and link storage docs

### DIFF
--- a/docs/src/concepts/crate-storage.md
+++ b/docs/src/concepts/crate-storage.md
@@ -10,4 +10,5 @@ Currently, the store is also responsible for storing rendered README pages (whic
 
 Because these can amount to a lot of storage space, it can be desirable to separate the crates' metadata (modelled by the crate index) and their actual contents (handled by the crate stores).  
 
-A crate store may be local (as files on disk, for instance) or remote (as blobs in AWS S3, for instance).  
+A crate store may be local (as files on disk, for instance) or remote (as blobs in AWS S3, for instance).
+For usage and configuration see [Crate stores](../whats-available/crate-stores.md).

--- a/docs/src/concepts/crate-storage.md
+++ b/docs/src/concepts/crate-storage.md
@@ -11,4 +11,4 @@ Currently, the store is also responsible for storing rendered README pages (whic
 Because these can amount to a lot of storage space, it can be desirable to separate the crates' metadata (modelled by the crate index) and their actual contents (handled by the crate stores).  
 
 A crate store may be local (as files on disk, for instance) or remote (as blobs in AWS S3, for instance).
-For usage and configuration see [Crate stores](../whats-available/crate-stores.md).
+For usage and configuration see [Available crate stores](../whats-available/crate-stores.md).

--- a/docs/src/whats-available/crate-stores.md
+++ b/docs/src/whats-available/crate-stores.md
@@ -17,12 +17,14 @@ path = "crate-storage"  # required: path of the directory in which to store the 
 's3': AWS S3 object storage
 ---------------------------
 
-This strategy stores crate archives and READMEs as objects within an AWS S3 bucket.
-To use the S3 storage type the feature `s3` needs to be enabled when compiling alexandrie.
-When using cargo to build use:
+This strategy stores crate archives and READMEs as objects within an AWS S3 bucket.  
+
+In order to use this storage strategy, the `s3` feature needs to be enabled when compiling Alexandrie.  
+
+When using Cargo to build, simply add the `s3` in the list of enabled features, like so:
 
 ```
-cargo build --release --features s3
+cargo build --release --features 's3'
 ```
 
 Here is an example of configuration to use this storage strategy:

--- a/docs/src/whats-available/crate-stores.md
+++ b/docs/src/whats-available/crate-stores.md
@@ -18,6 +18,12 @@ path = "crate-storage"  # required: path of the directory in which to store the 
 ---------------------------
 
 This strategy stores crate archives and READMEs as objects within an AWS S3 bucket.
+To use the S3 storage type the feature `s3` needs to be enabled when compiling alexandrie.
+When using cargo to build use:
+
+```
+cargo build --release --features s3
+```
 
 Here is an example of configuration to use this storage strategy:
 


### PR DESCRIPTION
Mentions the 's3' feature flag requirement for s3 in docs and adds links between the two storage pages.