### PR TITLE
Allow publishing backported crate versions

### DIFF
--- a/crates/alexandrie/src/api/crates/publish.rs
+++ b/crates/alexandrie/src/api/crates/publish.rs
@@ -292,8 +292,9 @@ pub(crate) async fn put(mut req: Request<State>) -> tide::Result {
                 }));
             }
 
-            //? Is the version higher than the latest known one?
-            let latest = state.index.latest_record(krate.name.as_str())?;
+            //? Is the attempted publication version higher than the latest version for that release?
+            let requirement = VersionReq::parse(&format!("^{}.0.0", crate_desc.vers.major))?;
+            let latest = state.index.match_record(krate.name.as_str(), requirement)?;
             if crate_desc.vers <= latest.vers {
                 return Err(Error::from(AlexError::VersionTooLow {
                     krate: krate.name,

--- a/crates/alexandrie/src/error.rs
+++ b/crates/alexandrie/src/error.rs
@@ -5,7 +5,7 @@ use diesel::result::Error as SQLError;
 use hex::FromHexError as HexError;
 use io::Error as IOError;
 use json::Error as JSONError;
-use semver::{SemVerError as SemverError, Version};
+use semver::{ReqParseError, SemVerError as SemverError, Version};
 use thiserror::Error;
 use toml::de::Error as TOMLError;
 
@@ -34,6 +34,9 @@ pub enum Error {
     /// Version parsing errors (invalid version format parsed, etc...).
     #[error("semver error: {0}")]
     SemverError(#[from] SemverError),
+    /// Version requirement parsing errors (invalid version requirement format parsed, etc...).
+    #[error("semver req parse error: {0}")]
+    SemverReqParseError(#[from] ReqParseError),
     /// Hexadecimal decoding errors (odd length, etc...).
     #[error("hex error: {0}")]
     HexError(#[from] HexError),


### PR DESCRIPTION
This PR fixes the issue that Alexandrie would always reject crate publications for versions lower than the absolute latest one.  
The more correct behaviour is to allow crate publication if the version is higher than the latest one **for that specific major version.**

It makes it possible for crates to publish bug fixes for both the latest major version and older ones that can still be maintained for compatibility reasons.

**Fixes #53.**