### PR TITLE
External authentication methods

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,11 +1,33 @@
-/.vscode
-/target
+# macOS hidden metadata file
+.DS_Store
+
+# dotenv folder
+/.env
+
+# Backup files from some editors
 **/*.rs.bk
+
+# Rust compilation folder
+/target
+
+# hidden folders from code editors
+/.vscode
+/.nova
+/.idea
+
+# daemon folder for `persist`
+/.persist
+
+# file for saving processes from `persist`
+/persist-dump.json
+
+# alexandrie local testing folders
+/app-data
 /crate-index
 /crate-storage
-.DS_Store
-.idea
-alexandrie.db
-crate-index.txt
-.env
+
+# SQLite database testing file
+/alexandrie.db
+
+# Password for Alexandrie's Docker setup
 docker/*/rootpass.txt

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -63,6 +63,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "aho-corasick"
+version = "0.7.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e37cfd5e7657ada45f742d6e99ca5788580b5c529dc78faf11ece6dc702656f"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "alexandrie"
 version = "0.1.0"
 dependencies = [
@@ -83,7 +92,11 @@ dependencies = [
  "hex",
  "log",
  "num-format",
+ "oauth2",
+ "once_cell",
  "percent-encoding 2.1.0",
+ "regex",
+ "reqwest",
  "ring",
  "semver 0.11.0",
  "serde",
@@ -254,6 +267,7 @@ dependencies = [
  "futures-lite",
  "num_cpus",
  "once_cell",
+ "tokio",
 ]
 
 [[package]]
@@ -880,6 +894,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "212d0f5754cb6769937f4501cc0e67f4f4483c8d2c3e1e922ee9edbe4ab4c7c0"
 
 [[package]]
+name = "encoding_rs"
+version = "0.8.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80df024fbc5ac80f87dfef0d9f5209a252f2a497f7f42944cff24d8253cac065"
+dependencies = [
+ "cfg-if 1.0.0",
+]
+
+[[package]]
 name = "event-listener"
 version = "2.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1120,8 +1143,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fcd999463524c52659517fe2cea98493cfe485d10565e7b0fb07dbba7ad2753"
 dependencies = [
  "cfg-if 1.0.0",
+ "js-sys",
  "libc",
  "wasi 0.10.0+wasi-snapshot-preview1",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1160,6 +1185,25 @@ dependencies = [
  "js-sys",
  "wasm-bindgen",
  "web-sys",
+]
+
+[[package]]
+name = "h2"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c06815895acec637cd6ed6e9662c935b866d20a106f8361892893a7d9234964"
+dependencies = [
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "http",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
 ]
 
 [[package]]
@@ -1321,6 +1365,7 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
+ "h2",
  "http",
  "http-body",
  "httparse",
@@ -1332,6 +1377,21 @@ dependencies = [
  "tower-service",
  "tracing",
  "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f9f7a97316d44c0af9b0301e65010573a853a9fc97046d7331d7f6bc0fd5a64"
+dependencies = [
+ "futures-util",
+ "hyper",
+ "log",
+ "rustls",
+ "tokio",
+ "tokio-rustls",
+ "webpki",
 ]
 
 [[package]]
@@ -1393,6 +1453,12 @@ checksum = "716d3d89f35ac6a34fd0eed635395f4c3b76fa889338a4632e5231a8684216bd"
 dependencies = [
  "cfg-if 1.0.0",
 ]
+
+[[package]]
+name = "ipnet"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68f2d64f2edebec4ce84ad108148e67e1064789bee435edc5b60ad398714a3a9"
 
 [[package]]
 name = "itoa"
@@ -1607,6 +1673,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "mime"
+version = "0.3.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
+
+[[package]]
 name = "miniz_oxide"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1735,6 +1807,26 @@ checksum = "05499f3756671c15885fee9034446956fff3f243d6077b91e5767df161f766b3"
 dependencies = [
  "hermit-abi",
  "libc",
+]
+
+[[package]]
+name = "oauth2"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80e47cfc4c0a1a519d9a025ebfbac3a2439d1b5cdf397d72dcb79b11d9920dab"
+dependencies = [
+ "base64 0.13.0",
+ "chrono",
+ "getrandom 0.2.3",
+ "http",
+ "rand 0.8.4",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "serde_path_to_error",
+ "sha2",
+ "thiserror",
+ "url 2.2.2",
 ]
 
 [[package]]
@@ -2207,6 +2299,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex"
+version = "1.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d07a8629359eb56f1e2fb1652bb04212c072a87ba68546a04065d525673ac461"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
 name = "regex-syntax"
 version = "0.6.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2219,6 +2322,45 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
 dependencies = [
  "winapi",
+]
+
+[[package]]
+name = "reqwest"
+version = "0.11.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51c732d463dd300362ffb44b7b125f299c23d2990411a4253824630ebc7467fb"
+dependencies = [
+ "base64 0.13.0",
+ "bytes",
+ "encoding_rs",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body",
+ "hyper",
+ "hyper-rustls",
+ "hyper-tls",
+ "ipnet",
+ "js-sys",
+ "lazy_static",
+ "log",
+ "mime",
+ "native-tls",
+ "percent-encoding 2.1.0",
+ "pin-project-lite 0.2.7",
+ "rustls",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "tokio",
+ "tokio-native-tls",
+ "tokio-rustls",
+ "url 2.2.2",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "webpki-roots",
+ "winreg",
 ]
 
 [[package]]
@@ -2333,6 +2475,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls"
+version = "0.19.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35edb675feee39aec9c99fa5ff985081995a06d594114ae14cbe797ad7b7a6d7"
+dependencies = [
+ "base64 0.13.0",
+ "log",
+ "ring",
+ "sct",
+ "webpki",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2383,6 +2538,16 @@ name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
+
+[[package]]
+name = "sct"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b362b83898e0e69f38515b82ee15aa80636befe47c3b6d3d89a911e78fc228ce"
+dependencies = [
+ "ring",
+ "untrusted",
+]
 
 [[package]]
 name = "security-framework"
@@ -2469,6 +2634,15 @@ checksum = "0f690853975602e1bfe1ccbf50504d67174e3bcf340f23b5ea9992e0587a52d8"
 dependencies = [
  "itoa",
  "ryu",
+ "serde",
+]
+
+[[package]]
+name = "serde_path_to_error"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0421d4f173fab82d72d6babf36d57fae38b994ca5c2d78e704260ba6d12118b"
+dependencies = [
  "serde",
 ]
 
@@ -3022,6 +3196,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-rustls"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc6844de72e57df1980054b38be3a9f4702aba4858be64dd700181a8a6d0e1b6"
+dependencies = [
+ "rustls",
+ "tokio",
+ "webpki",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d3725d3efa29485e87311c5b699de63cde14b00ed4d256b8318aa30ca452cd"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "log",
+ "pin-project-lite 0.2.7",
+ "tokio",
+]
+
+[[package]]
 name = "toml"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3301,6 +3500,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "webpki"
+version = "0.21.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e38c0608262c46d4a56202ebabdeb094cef7e560ca7a226c6bf055188aa4ea"
+dependencies = [
+ "ring",
+ "untrusted",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aabe153544e473b775453675851ecc86863d2a81d786d741f6b76778f2a48940"
+dependencies = [
+ "webpki",
+]
+
+[[package]]
 name = "wepoll-ffi"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3339,6 +3557,15 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "winreg"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0120db82e8a1e0b9fb3345a539c478767c0048d842860994d96113d5b667bd69"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "xattr"

--- a/alexandrie.toml
+++ b/alexandrie.toml
@@ -21,6 +21,35 @@ path = "assets"
 [frontend.templates]
 path = "templates"
 
+[frontend.auth.local]
+enabled = true
+allow_registration = true
+
+[frontend.auth.github]
+enabled = false
+client_id = "GITHUB_OAUTH_CLIENT_ID"
+client_secret = "GITHUB_OAUTH_CLIENT_SECRET"
+# Omit `allowed_organizations` to not require any organization membership.
+allowed_organizations = [
+    # Using this organization does not requires any specific team membership.
+    { name = "ORG_NAME_1" },
+    # But using this one does requires membership in one of specified teams.
+    { name = "ORG_NAME_2", allowed_teams = ["TEAM_NAME"] },
+]
+allow_registration = true
+
+[frontend.auth.gitlab]
+enabled = false
+origin = "https://gitlab.com"
+client_id = "GITLAB_OAUTH_CLIENT_ID"
+client_secret = "GITLAB_OAUTH_CLIENT_SECRET"
+# Omit `allowed_groups` to not require any organization membership.
+allowed_groups = [
+    "GROUP_1",
+    "GROUP_2",
+]
+allow_registration = true
+
 [database]
 # url = "mysql://root:root@127.0.0.1:3306/alexandrie"
 # url = "postgresql://root:root@127.0.0.1:5432/alexandrie"

--- a/crates/alexandrie/Cargo.toml
+++ b/crates/alexandrie/Cargo.toml
@@ -50,7 +50,7 @@ diesel = { version = "1.4.6", features = ["r2d2", "chrono"] }
 diesel_migrations = "1.4.0"
 
 # async primitives
-async-std = { version = "1.9.0", features = ["attributes"] }
+async-std = { version = "1.9.0", features = ["attributes", "tokio1"] }
 futures = "0.3.14"
 
 # error handling
@@ -68,6 +68,10 @@ handlebars = { version = "3.5.5", features = ["dir_source"], optional = true }
 time = { version = "0.2.26", optional = true }
 num-format = { version = "0.4.0", optional = true }
 bigdecimal = { version = "0.1.2", features = ["serde"], optional = true }
+oauth2 = { version = "4.1.0", optional = true }
+reqwest = { version = "0.11.5", optional = true, features = ["json"] }
+once_cell = { version = "1.8.0", optional = true }
+regex = { version = "1.5.4", optional = true }
 
 # logs
 log = "0.4.14"
@@ -81,12 +85,22 @@ slog-async = "2.6.0"
 default = ["frontend", "sqlite"]
 # default = ["frontend", "mysql"]
 # default = ["frontend", "postgres"]
-frontend = ["handlebars", "num-format", "bigdecimal", "time", "diesel/numeric"]
 mysql = ["diesel/mysql", "diesel_migrations/mysql"]
 sqlite = ["diesel/sqlite", "diesel_migrations/sqlite"]
 postgres = ["diesel/postgres", "diesel_migrations/postgres"]
 git2 = ["alexandrie-index/git2"]
 s3 = ["alexandrie-storage/s3"]
+frontend = [
+    "handlebars",
+    "oauth2",
+    "once_cell",
+    "regex",
+    "reqwest",
+    "num-format",
+    "bigdecimal",
+    "time",
+    "diesel/numeric",
+]
 
 [build-dependencies]
 shadow-rs = "0.5.25"

--- a/crates/alexandrie/src/api/account/login.rs
+++ b/crates/alexandrie/src/api/account/login.rs
@@ -56,13 +56,13 @@ pub async fn post(mut req: Request<State>) -> tide::Result {
             .inner_join(authors::table)
             .select((authors::id, salts::salt, authors::passwd))
             .filter(authors::email.eq(body.email.as_str()))
-            .first::<(i64, String, String)>(conn)
+            .first::<(i64, String, Option<String>)>(conn)
             .optional()?;
 
         //? Does the user exist?
         let (author_id, encoded_salt, encoded_expected_hash) = match results {
-            Some(results) => results,
-            None => {
+            Some((author_id, salt, Some(passwd))) => (author_id, salt, passwd),
+            _ => {
                 return Ok(utils::response::error(
                     StatusCode::Forbidden,
                     "invalid email/password combination.",

--- a/crates/alexandrie/src/api/account/register.rs
+++ b/crates/alexandrie/src/api/account/register.rs
@@ -107,7 +107,9 @@ pub async fn post(mut req: Request<State>) -> tide::Result {
         let new_author = NewAuthor {
             email: body.email.as_str(),
             name: body.name.as_str(),
-            passwd: encoded_derived_hash.as_str(),
+            passwd: Some(encoded_derived_hash.as_str()),
+            github_id: None,
+            gitlab_id: None,
         };
         diesel::insert_into(authors::table)
             .values(new_author)

--- a/crates/alexandrie/src/config/frontend/auth/github.rs
+++ b/crates/alexandrie/src/config/frontend/auth/github.rs
@@ -1,0 +1,68 @@
+use oauth2::basic::BasicClient;
+use oauth2::{AuthUrl, ClientId, ClientSecret, RedirectUrl, TokenUrl};
+use url::Url;
+use serde::{Deserialize, Serialize};
+
+use crate::error::Error;
+
+
+/// The configuration struct for the "github" authentication strategy.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct GithubAuthConfig {
+    /// Whether the strategy is enabled.
+    pub enabled: bool,
+    /// The client ID for the OAuth2 application as provided by GitHub.
+    pub client_id: String,
+    /// The client secret for the OAuth2 application as provided by GitHub.
+    pub client_secret: String,
+    /// The list of organizations for which membership of one of them is mandated.
+    pub allowed_organizations: Option<Vec<GithubAuthOrganizationConfig>>,
+    /// Whether creating a new account is allowed using this strategy.
+    pub allow_registration: bool,
+}
+
+/// The configuration struct for an an allowed organization for the "github" authentication strategy.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct GithubAuthOrganizationConfig {
+    /// The name of the organization.
+    pub name: String,
+    /// The list of teams for which membership of one of them is mandated.
+    pub allowed_teams: Option<Vec<String>>,
+}
+
+impl Default for GithubAuthConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            client_id: String::default(),
+            client_secret: String::default(),
+            allowed_organizations: None,
+            allow_registration: true,
+        }
+    }
+}
+
+
+/// The authentication state for the "github" strategy.
+pub struct GithubAuthState {
+    /// The OAuth2 client configured for the "github" strategy.
+    pub client: BasicClient,
+}
+
+impl GithubAuthState {
+    /// Create a new [`GithubAuthState`] from a [`GithubAuthConfig`] and the origin of the current Alexandrie instance.
+    pub fn new(config: &GithubAuthConfig, origin: &str) -> Result<Self, Error> {
+        let mut redirect_url = Url::parse(&origin)?;
+        redirect_url.set_path("/account/github/callback");
+
+        let client = BasicClient::new(
+            ClientId::new(config.client_id.clone()),
+            Some(ClientSecret::new(config.client_secret.clone())),
+            AuthUrl::new("https://github.com/login/oauth/authorize".to_string()).unwrap(),
+            Some(TokenUrl::new("https://github.com/login/oauth/access_token".to_string()).unwrap()),
+        )
+        .set_redirect_uri(RedirectUrl::from_url(redirect_url));
+
+        Ok(Self { client })
+    }
+}

--- a/crates/alexandrie/src/config/frontend/auth/github.rs
+++ b/crates/alexandrie/src/config/frontend/auth/github.rs
@@ -1,10 +1,9 @@
 use oauth2::basic::BasicClient;
 use oauth2::{AuthUrl, ClientId, ClientSecret, RedirectUrl, TokenUrl};
-use url::Url;
 use serde::{Deserialize, Serialize};
+use url::Url;
 
 use crate::error::Error;
-
 
 /// The configuration struct for the "github" authentication strategy.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -41,7 +40,6 @@ impl Default for GithubAuthConfig {
         }
     }
 }
-
 
 /// The authentication state for the "github" strategy.
 pub struct GithubAuthState {

--- a/crates/alexandrie/src/config/frontend/auth/gitlab.rs
+++ b/crates/alexandrie/src/config/frontend/auth/gitlab.rs
@@ -1,0 +1,70 @@
+use oauth2::basic::BasicClient;
+use oauth2::{AuthUrl, ClientId, ClientSecret, RedirectUrl, RevocationUrl, TokenUrl};
+use serde::{Deserialize, Serialize};
+use url::Url;
+
+use crate::error::Error;
+
+/// The configuration struct for the "gitlab" authentication strategy.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct GitlabAuthConfig {
+    /// Whether the strategy is enabled.
+    pub enabled: bool,
+    /// The origin at which the remote GitLab instance is reachable.
+    pub origin: Url,
+    /// The client ID for the OAuth2 application as provided by GitHub.
+    pub client_id: String,
+    /// The client secret for the OAuth2 application as provided by GitHub.
+    pub client_secret: String,
+    /// The list of allowed groups for authors to be authorized.
+    pub allowed_groups: Option<Vec<String>>,
+    /// Whether creating a new account is allowed using this strategy.
+    pub allow_registration: bool,
+}
+
+impl Default for GitlabAuthConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            origin: Url::parse("https://gitlab.com").unwrap(),
+            client_id: String::default(),
+            client_secret: String::default(),
+            allowed_groups: None,
+            allow_registration: true,
+        }
+    }
+}
+
+/// The authentication state for the "gitlab" strategy.
+pub struct GitlabAuthState {
+    /// The OAuth2 client configured for the "gitlab" strategy.
+    pub client: BasicClient,
+}
+
+impl GitlabAuthState {
+    /// Create a new [`GitlabAuthState`] from a [`GitlabAuthConfig`] and the origin of the current Alexandrie instance.
+    pub fn new(config: &GitlabAuthConfig, origin: &str) -> Result<Self, Error> {
+        let mut auth_url = config.origin.clone();
+        auth_url.set_path("/oauth/authorize");
+
+        let mut token_url = config.origin.clone();
+        token_url.set_path("/oauth/token");
+
+        let mut redirect_url = Url::parse(&origin)?;
+        redirect_url.set_path("/account/gitlab/callback");
+
+        let mut revocation_url = config.origin.clone();
+        revocation_url.set_path("/oauth/revoke");
+
+        let client = BasicClient::new(
+            ClientId::new(config.client_id.clone()),
+            Some(ClientSecret::new(config.client_secret.clone())),
+            AuthUrl::from_url(auth_url),
+            Some(TokenUrl::from_url(token_url)),
+        )
+        .set_redirect_uri(RedirectUrl::from_url(redirect_url))
+        .set_revocation_uri(RevocationUrl::from_url(revocation_url));
+
+        Ok(Self { client })
+    }
+}

--- a/crates/alexandrie/src/config/frontend/auth/local.rs
+++ b/crates/alexandrie/src/config/frontend/auth/local.rs
@@ -1,0 +1,32 @@
+use serde::{Deserialize, Serialize};
+
+use crate::error::Error;
+
+/// The configuration struct for the "local" authentication strategy.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct LocalAuthConfig {
+    /// Whether the strategy is enabled.
+    pub enabled: bool,
+    /// Whether creating a new account is allowed using this strategy.
+    pub allow_registration: bool,
+}
+
+impl Default for LocalAuthConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            allow_registration: true,
+        }
+    }
+}
+
+
+/// The authentication state for the "local" strategy.
+pub struct LocalAuthState {}
+
+impl LocalAuthState {
+    /// Create a new [`LocalAuthState`] from a [`LocalAuthConfig`].
+    pub fn new(_: &LocalAuthConfig) -> Result<Self, Error> {
+        Ok(Self {})
+    }
+}

--- a/crates/alexandrie/src/config/frontend/auth/local.rs
+++ b/crates/alexandrie/src/config/frontend/auth/local.rs
@@ -20,7 +20,6 @@ impl Default for LocalAuthConfig {
     }
 }
 
-
 /// The authentication state for the "local" strategy.
 pub struct LocalAuthState {}
 

--- a/crates/alexandrie/src/config/frontend/auth/mod.rs
+++ b/crates/alexandrie/src/config/frontend/auth/mod.rs
@@ -1,4 +1,4 @@
-use serde::{Serialize, Deserialize};
+use serde::{Deserialize, Serialize};
 
 /// Types for the "github" authentication strategy.
 pub mod github;
@@ -7,9 +7,9 @@ pub mod gitlab;
 /// Types for the "local" authentication strategy.
 pub mod local;
 
-use crate::config::frontend::auth::github::{GithubAuthState, GithubAuthConfig};
-use crate::config::frontend::auth::gitlab::{GitlabAuthState, GitlabAuthConfig};
-use crate::config::frontend::auth::local::{LocalAuthState, LocalAuthConfig};
+use crate::config::frontend::auth::github::{GithubAuthConfig, GithubAuthState};
+use crate::config::frontend::auth::gitlab::{GitlabAuthConfig, GitlabAuthState};
+use crate::config::frontend::auth::local::{LocalAuthConfig, LocalAuthState};
 use crate::error::Error;
 
 /// The configuration struct for authentication strategies.
@@ -27,7 +27,6 @@ pub struct AuthConfig {
     #[serde(default)]
     pub gitlab: GitlabAuthConfig,
 }
-
 
 /// The authentication state, having things like OAuth clients for external authentication.
 pub struct AuthState {

--- a/crates/alexandrie/src/config/frontend/auth/mod.rs
+++ b/crates/alexandrie/src/config/frontend/auth/mod.rs
@@ -1,0 +1,61 @@
+use serde::{Serialize, Deserialize};
+
+/// Types for the "github" authentication strategy.
+pub mod github;
+/// Types for the "gitlab" authentication strategy.
+pub mod gitlab;
+/// Types for the "local" authentication strategy.
+pub mod local;
+
+use crate::config::frontend::auth::github::{GithubAuthState, GithubAuthConfig};
+use crate::config::frontend::auth::gitlab::{GitlabAuthState, GitlabAuthConfig};
+use crate::config::frontend::auth::local::{LocalAuthState, LocalAuthConfig};
+use crate::error::Error;
+
+/// The configuration struct for authentication strategies.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct AuthConfig {
+    /// The origin at which this current instance of Alexandrie is reachable.
+    pub origin: String,
+    /// Configuration regarding the "local" authentication strategy.
+    #[serde(default)]
+    pub local: LocalAuthConfig,
+    /// Configuration regarding the "github" authentication strategy.
+    #[serde(default)]
+    pub github: GithubAuthConfig,
+    /// Configuration regarding the "gitlab" authentication strategy.
+    #[serde(default)]
+    pub gitlab: GitlabAuthConfig,
+}
+
+
+/// The authentication state, having things like OAuth clients for external authentication.
+pub struct AuthState {
+    /// The authentication state for the "local" strategy, if enabled.
+    pub local: Option<LocalAuthState>,
+    /// The authentication state for the "github" strategy, if enabled.
+    pub github: Option<GithubAuthState>,
+    /// The authentication state for the "gitlab" strategy, if enabled.
+    pub gitlab: Option<GitlabAuthState>,
+}
+
+impl AuthState {
+    /// Create a new [`AuthState`] from an [`AuthConfig`].
+    pub fn new(config: &AuthConfig) -> Result<Self, Error> {
+        let local = (config.local.enabled)
+            .then(|| LocalAuthState::new(&config.local))
+            .transpose()?;
+        let github = (config.github.enabled)
+            .then(|| GithubAuthState::new(&config.github, &config.origin))
+            .transpose()?;
+        let gitlab = (config.gitlab.enabled)
+            .then(|| GitlabAuthState::new(&config.gitlab, &config.origin))
+            .transpose()?;
+
+        Ok(Self {
+            local,
+            github,
+            gitlab,
+        })
+    }
+}

--- a/crates/alexandrie/src/config/mod.rs
+++ b/crates/alexandrie/src/config/mod.rs
@@ -2,7 +2,6 @@ use serde::{Deserialize, Serialize};
 
 /// Database configuration (`[database]` section).
 pub mod database;
-
 /// Frontend configuration (`[frontend]` section).
 #[cfg(feature = "frontend")]
 pub mod frontend;

--- a/crates/alexandrie/src/db/models.rs
+++ b/crates/alexandrie/src/db/models.rs
@@ -80,7 +80,11 @@ pub struct Author {
     /// The author's displayable name.
     pub name: String,
     /// The author's SHA512-hashed password.
-    pub passwd: String,
+    pub passwd: Option<String>,
+    /// The author's GitHub user ID.
+    pub github_id: Option<String>,
+    /// The author's GitLab user ID.
+    pub gitlab_id: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Queryable, Insertable)]
@@ -93,7 +97,11 @@ pub struct NewAuthor<'a> {
     /// The author's displayable name.
     pub name: &'a str,
     /// The author's SHA512-hashed password.
-    pub passwd: &'a str,
+    pub passwd: Option<&'a str>,
+    /// The author's GitHub user ID.
+    pub github_id: Option<&'a str>,
+    /// The author's GitLab user ID.
+    pub gitlab_id: Option<&'a str>,
 }
 
 #[derive(

--- a/crates/alexandrie/src/db/schema.rs
+++ b/crates/alexandrie/src/db/schema.rs
@@ -8,7 +8,11 @@ table! {
         /// The author's displayable name.
         name -> Varchar,
         /// The author's SHA512-hashed password.
-        passwd -> Varchar,
+        passwd -> Nullable<Varchar>,
+        /// The author's GitHub user ID.
+        github_id -> Nullable<Varchar>,
+        /// The author's GitLab user ID.
+        gitlab_id -> Nullable<Varchar>,
     }
 }
 

--- a/crates/alexandrie/src/error.rs
+++ b/crates/alexandrie/src/error.rs
@@ -22,6 +22,9 @@ pub enum Error {
     /// An IO error (file not found, access forbidden, etc...).
     #[error("IO error: {0}")]
     IOError(#[from] IOError),
+    /// An error while parsing a URL.
+    #[error("URL parse error: {0}")]
+    UrlParseError(#[from] url::ParseError),
     /// JSON (de)serialization error (invalid JSON parsed, etc...).
     #[error("JSON error: {0}")]
     JSONError(#[from] JSONError),

--- a/crates/alexandrie/src/frontend/account/github/attach.rs
+++ b/crates/alexandrie/src/frontend/account/github/attach.rs
@@ -1,0 +1,46 @@
+use oauth2::{CsrfToken, Scope};
+use tide::{Request, StatusCode};
+
+use crate::frontend::account::github::{GithubLoginState, GITHUB_LOGIN_STATE_KEY};
+use crate::utils;
+use crate::utils::auth::AuthExt;
+use crate::State;
+
+pub(crate) async fn get(mut req: Request<State>) -> tide::Result {
+    if !req.is_authenticated() {
+        return Ok(utils::response::redirect("/account/manage"));
+    }
+
+    let github_config = &req.state().frontend.config.auth.github;
+    let github_state = match req.state().frontend.auth.github.as_ref() {
+        Some(state) => state,
+        None => {
+            return utils::response::error_html(
+                req.state(),
+                None,
+                StatusCode::BadRequest,
+                "authentication using GitHub is not allowed on this instance",
+            );
+        }
+    };
+
+    let mut builder = github_state
+        .client
+        .authorize_url(CsrfToken::new_random)
+        .add_scope(Scope::new("read:user".to_string()))
+        .add_scope(Scope::new("user:email".to_string()));
+
+    if github_config.allowed_organizations.is_some() {
+        builder = builder.add_scope(Scope::new("read:org".to_string()));
+    }
+
+    let (url, state) = builder.url();
+
+    let data = GithubLoginState {
+        state,
+        attach: true,
+    };
+    req.session_mut().insert(GITHUB_LOGIN_STATE_KEY, &data)?;
+
+    return Ok(utils::response::redirect(url.as_str()));
+}

--- a/crates/alexandrie/src/frontend/account/github/attach.rs
+++ b/crates/alexandrie/src/frontend/account/github/attach.rs
@@ -7,9 +7,9 @@ use crate::utils::auth::AuthExt;
 use crate::State;
 
 pub(crate) async fn get(mut req: Request<State>) -> tide::Result {
-    if !req.is_authenticated() {
+    let Some(author) = req.get_author() else {
         return Ok(utils::response::redirect("/account/manage"));
-    }
+    };
 
     let github_config = &req.state().frontend.config.auth.github;
     let github_state = match req.state().frontend.auth.github.as_ref() {
@@ -17,7 +17,7 @@ pub(crate) async fn get(mut req: Request<State>) -> tide::Result {
         None => {
             return utils::response::error_html(
                 req.state(),
-                None,
+                Some(author),
                 StatusCode::BadRequest,
                 "authentication using GitHub is not allowed on this instance",
             );

--- a/crates/alexandrie/src/frontend/account/github/callback.rs
+++ b/crates/alexandrie/src/frontend/account/github/callback.rs
@@ -1,0 +1,358 @@
+use std::time::Duration;
+
+use diesel::prelude::*;
+use oauth2::reqwest::async_http_client;
+use oauth2::{AuthorizationCode, TokenResponse};
+use ring::digest as hasher;
+use ring::rand::{SecureRandom, SystemRandom};
+use serde::{Deserialize, Serialize};
+use tide::{Request, StatusCode};
+
+use crate::config::frontend::auth::github::GithubAuthOrganizationConfig;
+use crate::db::models::{Author, NewAuthor, NewSalt};
+use crate::db::schema::{authors, salts};
+use crate::frontend::account::github::GITHUB_LOGIN_STATE_KEY;
+use crate::utils;
+use crate::utils::auth::AuthExt;
+use crate::State;
+
+use super::GithubLoginState;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct CallbackQueryData {
+    code: String,
+    state: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct GithubUser {
+    id: u64,
+    login: String,
+    name: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct GithubUserEmail {
+    email: String,
+    verified: bool,
+    primary: bool,
+    visibility: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct GithubUserOrg {
+    id: u64,
+    login: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct GithubUserTeam {
+    id: u64,
+    organization: GithubUserTeamOrg,
+    // "parent": null,
+    slug: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct GithubUserTeamOrg {
+    id: u64,
+    login: String,
+}
+
+pub(crate) async fn get(mut req: Request<State>) -> tide::Result {
+    let data: GithubLoginState = match req.session().get(GITHUB_LOGIN_STATE_KEY) {
+        Some(data) => data,
+        None => {
+            return utils::response::error_html(
+                req.state(),
+                None,
+                StatusCode::BadRequest,
+                "no authentication is currently being performed",
+            );
+        }
+    };
+    req.session_mut().remove("login.github");
+
+    let current_author = match (data.attach, req.get_author()) {
+        (true, Some(author)) => Some(author),
+        (true, None) => {
+            return utils::response::error_html(
+                req.state(),
+                None,
+                StatusCode::BadRequest,
+                "attaching to an account requires to be logged-in",
+            );
+        }
+        (false, Some(_)) => {
+            return Ok(utils::response::redirect("/"));
+        }
+        (false, None) => None,
+    };
+
+    let query: CallbackQueryData = req.query()?;
+
+    let github_config = &req.state().frontend.config.auth.github;
+    let github_state = match req.state().frontend.auth.github.as_ref() {
+        Some(state) => state,
+        None => {
+            return utils::response::error_html(
+                req.state(),
+                None,
+                StatusCode::BadRequest,
+                "authentication using GitHub is not allowed on this instance",
+            );
+        }
+    };
+
+    let allow_register = github_config.allow_registration;
+
+    if query.state.as_str() != data.state.secret() {
+        return utils::response::error_html(
+            req.state(),
+            None,
+            StatusCode::BadRequest,
+            "CSRF token is different than expected",
+        );
+    }
+
+    let code = AuthorizationCode::new(query.code);
+    let token_response = github_state
+        .client
+        .exchange_code(code)
+        .request_async(async_http_client)
+        .await?;
+
+    let token = token_response.access_token();
+    let token = format!("token {}", token.secret());
+
+    //? The GitHub REST API v3 requires a user-agent string with the name of the application.
+    let client = reqwest::Client::builder()
+        .user_agent("alexandrie/0.1.0")
+        .build()?;
+
+    //? Get GitHub user information.
+    let user_info: GithubUser = client
+        .get("https://api.github.com/user")
+        .header("accept", "application/vnd.github.v3+json")
+        .header("authorization", &token)
+        .send()
+        .await?
+        .error_for_status()?
+        .json()
+        .await?;
+
+    //? Get the list of their email addresses (to find their primary email address).
+    let emails: Vec<GithubUserEmail> = client
+        .get("https://api.github.com/user/emails")
+        .header("accept", "application/vnd.github.v3+json")
+        .header("authorization", &token)
+        .send()
+        .await?
+        .error_for_status()?
+        .json()
+        .await?;
+
+    //? Find the primary email address.
+    let maybe_primary_email = emails.into_iter().find(|email| email.primary == true);
+    let primary_email = match maybe_primary_email {
+        Some(email) => email,
+        None => {
+            return utils::response::error_html(
+                req.state(),
+                None,
+                StatusCode::NotFound,
+                "could not find primary email",
+            );
+        }
+    };
+
+    if let Some(allowed_organizations) = github_config.allowed_organizations.as_ref() {
+        //? Get list of user organizations that are also specified in the configuration.
+        let found_orgs = fetch_relevent_user_orgs(allowed_organizations, &client, &token).await?;
+
+        //? If the configuration doesn't require specific team memberships for any of these orgs, the user is then already allowed.
+        let already_allowed = found_orgs.iter().any(|it| it.allowed_teams.is_none());
+
+        if found_orgs.is_empty()
+            || (!already_allowed
+                && !check_team_memberships(allowed_organizations, &client, &token).await?)
+        {
+            //? The error message presented to users is intentionally vague about what check failed.
+            // TODO(hirevo): maybe it is ok to say that it is an organization membership issue ?
+            return utils::response::error_html(
+                req.state(),
+                None,
+                StatusCode::NotFound,
+                "GitHub user doesn't fulfill required conditions for access",
+            );
+        }
+    }
+
+    let state = req.state().clone();
+    let db = &state.db;
+
+    let transaction = db.transaction(move |conn| {
+        let github_id = user_info.id.to_string();
+
+        //? If we are attaching to an existing account:
+        if let Some(current_author) = current_author {
+            //? Attach the GitHub account to this author.
+            //?
+            //? This will fail if the GitHub account is already claimed,
+            //? because the `github_id` column is marked `unique`.
+            diesel::update(authors::table.find(current_author.id))
+                .set(authors::github_id.eq(github_id.as_str()))
+                .execute(conn)?;
+
+            return Ok(utils::response::redirect("/"));
+        }
+
+        //? Is this GitHub account attached to an existing author ?
+        let maybe_author: Option<Author> = authors::table
+            .filter(authors::github_id.eq(github_id.as_str()))
+            .first(conn)
+            .optional()?;
+
+        let author_id = if let Some(found_author) = maybe_author {
+            // TODO (hirevo): (maybe) update user's details to the ones from GitHub ?
+            found_author.id
+        } else if allow_register {
+            //? Generate the user's authentication salt.
+            let decoded_generated_salt = {
+                let mut data = [0u8; 16];
+                let rng = SystemRandom::new();
+                rng.fill(&mut data).unwrap();
+                hasher::digest(&hasher::SHA512, data.as_ref())
+            };
+
+            //? Insert the new author data.
+            let new_author = NewAuthor {
+                email: primary_email.email.as_str(),
+                name: user_info
+                    .name
+                    .as_deref()
+                    .unwrap_or(user_info.login.as_str()),
+                passwd: None,
+                github_id: Some(github_id.as_str()),
+                gitlab_id: None,
+            };
+            diesel::insert_into(authors::table)
+                .values(new_author)
+                .execute(conn)?;
+
+            //? Fetch the newly-inserted author back.
+            let author_id = authors::table
+                .select(authors::id)
+                .filter(authors::github_id.eq(github_id.as_str()))
+                .first::<i64>(conn)?;
+
+            //? Store the author's newly-generated authentication salt.
+            let encoded_generated_salt = hex::encode(decoded_generated_salt.as_ref());
+            let new_salt = NewSalt {
+                author_id,
+                salt: encoded_generated_salt.as_str(),
+            };
+            diesel::insert_into(salts::table)
+                .values(new_salt)
+                .execute(conn)?;
+
+            author_id
+        } else {
+            return utils::response::error_html(
+                req.state(),
+                None,
+                StatusCode::NotFound,
+                "user registration is forbidden for this instance",
+            );
+        };
+
+        //? Get the maximum duration of the session.
+        let expiry = Duration::from_secs(86_400); // 1 day / 24 hours
+
+        //? Set the user's session.
+        req.session_mut().insert("author.id", author_id)?;
+        req.session_mut().expire_in(expiry);
+
+        return Ok(utils::response::redirect("/"));
+    });
+
+    transaction.await
+}
+
+async fn fetch_relevent_user_orgs<'a>(
+    allowed_organizations: &'a [GithubAuthOrganizationConfig],
+    client: &reqwest::Client,
+    token: &str,
+) -> tide::Result<Vec<&'a GithubAuthOrganizationConfig>> {
+    let mut found_orgs = Vec::new();
+
+    for page_number in 1.. {
+        //? Get the list of the user's organizations.
+        let orgs: Vec<GithubUserOrg> = client
+            .get(format!(
+                "https://api.github.com/user/orgs?page={}",
+                page_number
+            ))
+            .header("accept", "application/vnd.github.v3+json")
+            .header("authorization", token)
+            .send()
+            .await?
+            .error_for_status()?
+            .json()
+            .await?;
+
+        //? No more organizations to be listed.
+        if orgs.is_empty() {
+            break;
+        }
+
+        //? Checks that the GitHub user is within one of the allowed organizations.
+        let iter = orgs
+            .iter()
+            .filter_map(|org| allowed_organizations.iter().find(|it| it.name == org.login));
+        found_orgs.extend(iter);
+    }
+
+    Ok(found_orgs)
+}
+
+async fn check_team_memberships(
+    allowed_organizations: &[GithubAuthOrganizationConfig],
+    client: &reqwest::Client,
+    token: &str,
+) -> tide::Result<bool> {
+    for page_number in 1.. {
+        //? Get the list of the user's teams (which includes organizations).
+        let teams: Vec<GithubUserTeam> = client
+            .get(format!(
+                "https://api.github.com/user/teams?page={}",
+                page_number
+            ))
+            .header("accept", "application/vnd.github.v3+json")
+            .header("authorization", token)
+            .send()
+            .await?
+            .error_for_status()?
+            .json()
+            .await?;
+
+        //? No more teams to be listed.
+        if teams.is_empty() {
+            break;
+        }
+
+        //? Checks that the GitHub user is within one of the allowed teams within one of the allowed organizations.
+        let allowed = teams.iter().any(|team| {
+            allowed_organizations.iter().any(|it| {
+                it.name == team.organization.login
+                    && (it.allowed_teams.as_ref()).map_or(true, |it| it.contains(&team.slug))
+            })
+        });
+
+        if allowed {
+            return Ok(true);
+        }
+    }
+
+    Ok(false)
+}

--- a/crates/alexandrie/src/frontend/account/github/detach.rs
+++ b/crates/alexandrie/src/frontend/account/github/detach.rs
@@ -1,0 +1,26 @@
+use diesel::prelude::*;
+use tide::Request;
+
+use crate::db::schema::authors;
+use crate::utils;
+use crate::utils::auth::AuthExt;
+use crate::State;
+
+pub(crate) async fn get(req: Request<State>) -> tide::Result {
+    let author = match req.get_author() {
+        Some(author) => author,
+        None => {
+            return Ok(utils::response::redirect("/account/manage"));
+        }
+    };
+
+    (req.state().db)
+        .run(move |conn| {
+            diesel::update(authors::table.find(author.id))
+                .set(authors::github_id.eq(None::<String>))
+                .execute(conn)
+        })
+        .await?;
+
+    Ok(utils::response::redirect("/account/manage"))
+}

--- a/crates/alexandrie/src/frontend/account/github/detach.rs
+++ b/crates/alexandrie/src/frontend/account/github/detach.rs
@@ -1,18 +1,25 @@
 use diesel::prelude::*;
-use tide::Request;
+use tide::{Request, StatusCode};
 
 use crate::db::schema::authors;
+use crate::frontend::account::utils::count_auth_methods;
 use crate::utils;
 use crate::utils::auth::AuthExt;
 use crate::State;
 
 pub(crate) async fn get(req: Request<State>) -> tide::Result {
-    let author = match req.get_author() {
-        Some(author) => author,
-        None => {
-            return Ok(utils::response::redirect("/account/manage"));
-        }
+    let Some(author) = req.get_author() else {
+        return Ok(utils::response::redirect("/account/manage"));
     };
+
+    if count_auth_methods(&author) < 2 {
+        return utils::response::error_html(
+            req.state(),
+            Some(author),
+            StatusCode::BadRequest,
+            "too few authentication methods remaining",
+        );
+    }
 
     (req.state().db)
         .run(move |conn| {

--- a/crates/alexandrie/src/frontend/account/github/mod.rs
+++ b/crates/alexandrie/src/frontend/account/github/mod.rs
@@ -1,0 +1,62 @@
+use oauth2::{CsrfToken, Scope};
+use serde::{Deserialize, Serialize};
+use tide::{Request, StatusCode};
+
+/// Callback endpoint for the "github" authentication strategy.
+pub mod callback;
+/// Endpoint to attach to an existing Alexandrie account.
+pub mod attach;
+/// Endpoint to detach from an existing Alexandrie account.
+pub mod detach;
+
+use crate::utils;
+use crate::utils::auth::AuthExt;
+use crate::utils::response::common;
+use crate::State;
+
+const GITHUB_LOGIN_STATE_KEY: &str = "login.github";
+
+#[derive(Clone, Serialize, Deserialize)]
+struct GithubLoginState {
+    state: CsrfToken,
+    attach: bool,
+}
+
+pub(crate) async fn get(mut req: Request<State>) -> tide::Result {
+    if let Some(author) = req.get_author() {
+        let state = req.state().as_ref();
+        return common::already_logged_in(state, author);
+    }
+
+    let github_config = &req.state().frontend.config.auth.github;
+    let github_state = match req.state().frontend.auth.github.as_ref() {
+        Some(state) => state,
+        None => {
+            return utils::response::error_html(
+                req.state(),
+                None,
+                StatusCode::BadRequest,
+                "authentication using GitHub is not allowed on this instance",
+            );
+        }
+    };
+
+    let mut builder = github_state
+        .client
+        .authorize_url(CsrfToken::new_random)
+        .add_scope(Scope::new("read:user".to_string()))
+        .add_scope(Scope::new("user:email".to_string()));
+
+    if github_config.allowed_organizations.is_some() {
+        builder = builder.add_scope(Scope::new("read:org".to_string()));
+    }
+
+    let (url, state) = builder
+        .add_extra_param("allow_signup", github_config.allow_registration.to_string())
+        .url();
+
+    let data = GithubLoginState { state, attach: false };
+    req.session_mut().insert(GITHUB_LOGIN_STATE_KEY, &data)?;
+
+    return Ok(utils::response::redirect(url.as_str()));
+}

--- a/crates/alexandrie/src/frontend/account/github/mod.rs
+++ b/crates/alexandrie/src/frontend/account/github/mod.rs
@@ -2,10 +2,10 @@ use oauth2::{CsrfToken, Scope};
 use serde::{Deserialize, Serialize};
 use tide::{Request, StatusCode};
 
-/// Callback endpoint for the "github" authentication strategy.
-pub mod callback;
 /// Endpoint to attach to an existing Alexandrie account.
 pub mod attach;
+/// Callback endpoint for the "github" authentication strategy.
+pub mod callback;
 /// Endpoint to detach from an existing Alexandrie account.
 pub mod detach;
 
@@ -55,7 +55,10 @@ pub(crate) async fn get(mut req: Request<State>) -> tide::Result {
         .add_extra_param("allow_signup", github_config.allow_registration.to_string())
         .url();
 
-    let data = GithubLoginState { state, attach: false };
+    let data = GithubLoginState {
+        state,
+        attach: false,
+    };
     req.session_mut().insert(GITHUB_LOGIN_STATE_KEY, &data)?;
 
     return Ok(utils::response::redirect(url.as_str()));

--- a/crates/alexandrie/src/frontend/account/gitlab/attach.rs
+++ b/crates/alexandrie/src/frontend/account/gitlab/attach.rs
@@ -1,0 +1,39 @@
+use oauth2::{CsrfToken, Scope};
+use tide::{Request, StatusCode};
+
+use crate::frontend::account::gitlab::{GitlabLoginState, GITLAB_LOGIN_STATE_KEY};
+use crate::utils;
+use crate::utils::auth::AuthExt;
+use crate::State;
+
+pub(crate) async fn get(mut req: Request<State>) -> tide::Result {
+    if !req.is_authenticated() {
+        return Ok(utils::response::redirect("/account/manage"));
+    }
+
+    let gitlab_state = match req.state().frontend.auth.gitlab.as_ref() {
+        Some(state) => state,
+        None => {
+            return utils::response::error_html(
+                req.state(),
+                None,
+                StatusCode::BadRequest,
+                "authentication using GitLab is not allowed on this instance",
+            );
+        }
+    };
+
+    let (url, state) = gitlab_state
+        .client
+        .authorize_url(CsrfToken::new_random)
+        .add_scope(Scope::new("read_api".to_string()))
+        .url();
+
+    let data = GitlabLoginState {
+        state,
+        attach: true,
+    };
+    req.session_mut().insert(GITLAB_LOGIN_STATE_KEY, &data)?;
+
+    return Ok(utils::response::redirect(url.as_str()));
+}

--- a/crates/alexandrie/src/frontend/account/gitlab/attach.rs
+++ b/crates/alexandrie/src/frontend/account/gitlab/attach.rs
@@ -7,16 +7,16 @@ use crate::utils::auth::AuthExt;
 use crate::State;
 
 pub(crate) async fn get(mut req: Request<State>) -> tide::Result {
-    if !req.is_authenticated() {
+    let Some(author) = req.get_author() else {
         return Ok(utils::response::redirect("/account/manage"));
-    }
+    };
 
     let gitlab_state = match req.state().frontend.auth.gitlab.as_ref() {
         Some(state) => state,
         None => {
             return utils::response::error_html(
                 req.state(),
-                None,
+                Some(author),
                 StatusCode::BadRequest,
                 "authentication using GitLab is not allowed on this instance",
             );

--- a/crates/alexandrie/src/frontend/account/gitlab/callback.rs
+++ b/crates/alexandrie/src/frontend/account/gitlab/callback.rs
@@ -1,0 +1,282 @@
+use std::time::Duration;
+
+use diesel::prelude::*;
+use oauth2::reqwest::async_http_client;
+use oauth2::{AccessToken, AuthorizationCode, TokenResponse};
+use once_cell::sync::Lazy;
+use regex::Regex;
+use ring::digest as hasher;
+use ring::rand::{SecureRandom, SystemRandom};
+use serde::{Deserialize, Serialize};
+use tide::{Request, StatusCode};
+use url::Url;
+
+use crate::db::models::{Author, NewAuthor, NewSalt};
+use crate::db::schema::{authors, salts};
+use crate::frontend::account::gitlab::GITLAB_LOGIN_STATE_KEY;
+use crate::utils;
+use crate::utils::auth::AuthExt;
+use crate::State;
+
+use super::GitlabLoginState;
+
+static LINK_HEADER_REGEX: Lazy<Regex> =
+    Lazy::new(|| Regex::new(r#"<([^>]+)>; rel="next""#).unwrap());
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct CallbackQueryData {
+    code: String,
+    state: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct GitlabUser {
+    id: u64,
+    email: String,
+    username: String,
+    name: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct GitlabGroup {
+    id: u64,
+    name: String,
+    path: String,
+    full_name: String,
+    full_path: String,
+    parent_id: Option<u64>,
+}
+
+pub(crate) async fn get(mut req: Request<State>) -> tide::Result {
+    let data: GitlabLoginState = match req.session().get(GITLAB_LOGIN_STATE_KEY) {
+        Some(data) => data,
+        None => {
+            return utils::response::error_html(
+                req.state(),
+                None,
+                StatusCode::BadRequest,
+                "no authentication is currently being performed",
+            );
+        }
+    };
+    req.session_mut().remove("login.gitlab");
+
+    let current_author = match (data.attach, req.get_author()) {
+        (true, Some(author)) => Some(author),
+        (true, None) => {
+            return utils::response::error_html(
+                req.state(),
+                None,
+                StatusCode::BadRequest,
+                "attaching to an account requires to be logged-in",
+            );
+        }
+        (false, Some(_)) => {
+            return Ok(utils::response::redirect("/"));
+        }
+        (false, None) => None,
+    };
+
+    let query: CallbackQueryData = req.query()?;
+
+    let gitlab_config = &req.state().frontend.config.auth.gitlab;
+    let gitlab_state = match req.state().frontend.auth.gitlab.as_ref() {
+        Some(state) => state,
+        None => {
+            return utils::response::error_html(
+                req.state(),
+                None,
+                StatusCode::BadRequest,
+                "authentication using GitLab is not allowed on this instance",
+            );
+        }
+    };
+
+    let allow_register = gitlab_config.allow_registration;
+
+    if query.state.as_str() != data.state.secret() {
+        return utils::response::error_html(
+            req.state(),
+            None,
+            StatusCode::BadRequest,
+            "CSRF token is different than expected",
+        );
+    }
+
+    let code = AuthorizationCode::new(query.code);
+    let token_response = gitlab_state
+        .client
+        .exchange_code(code)
+        .request_async(async_http_client)
+        .await?;
+
+    let token = token_response.access_token();
+
+    let client = reqwest::Client::builder()
+        .user_agent("alexandrie/0.1.0")
+        .build()?;
+
+    let mut request_url = gitlab_config.origin.clone();
+    request_url.set_path("/api/v4/user");
+
+    let user_info: GitlabUser = client
+        .get(request_url)
+        .bearer_auth(token.secret().clone())
+        .send()
+        .await?
+        .error_for_status()?
+        .json()
+        .await?;
+
+    if let Some(allowed_groups) = gitlab_config.allowed_groups.as_ref() {
+        let allowed =
+            check_memberships(&gitlab_config.origin, allowed_groups, &client, &token).await?;
+
+        if !allowed {
+            //? The error message presented to users is intentionally vague about what check failed.
+            // TODO(hirevo): maybe it is ok to say that it is an organization membership issue ?
+            return utils::response::error_html(
+                req.state(),
+                None,
+                StatusCode::NotFound,
+                "GitLab user doesn't fulfill required conditions for access",
+            );
+        }
+    }
+
+    let state = req.state().clone();
+    let db = &state.db;
+
+    let transaction = db.transaction(move |conn| {
+        let gitlab_id = user_info.id.to_string();
+
+        //? If we are attaching to an existing account:
+        if let Some(current_author) = current_author {
+            //? Attach the GitLab account to this author.
+            //?
+            //? This will fail if the GitLab account is already claimed,
+            //? because the `gitlab_id` column is marked `unique`.
+            diesel::update(authors::table.find(current_author.id))
+                .set(authors::gitlab_id.eq(gitlab_id.as_str()))
+                .execute(conn)?;
+
+            return Ok(utils::response::redirect("/"));
+        }
+
+        //? Is this GitLab account attached to an existing author ?
+        let maybe_author: Option<Author> = authors::table
+            .filter(authors::gitlab_id.eq(gitlab_id.as_str()))
+            .first(conn)
+            .optional()?;
+
+        let author_id = if let Some(found_author) = maybe_author {
+            // TODO (hirevo): (maybe) update user's details to the ones from Gitlab ?
+            // TODO (hirevo): add mechanism for linking GitLab account to an already existing account.
+
+            found_author.id
+        } else if allow_register {
+            //? Generate the user's authentication salt.
+            let decoded_generated_salt = {
+                let mut data = [0u8; 16];
+                let rng = SystemRandom::new();
+                rng.fill(&mut data).unwrap();
+                hasher::digest(&hasher::SHA512, data.as_ref())
+            };
+
+            //? Insert the new author data.
+            let new_author = NewAuthor {
+                email: user_info.email.as_str(),
+                name: user_info
+                    .name
+                    .as_deref()
+                    .unwrap_or(user_info.username.as_str()),
+                passwd: None,
+                github_id: None,
+                gitlab_id: Some(gitlab_id.as_str()),
+            };
+            diesel::insert_into(authors::table)
+                .values(new_author)
+                .execute(conn)?;
+
+            //? Fetch the newly-inserted author back.
+            let author_id = authors::table
+                .select(authors::id)
+                .filter(authors::gitlab_id.eq(gitlab_id.as_str()))
+                .first::<i64>(conn)?;
+
+            //? Store the author's newly-generated authentication salt.
+            let encoded_generated_salt = hex::encode(decoded_generated_salt.as_ref());
+            let new_salt = NewSalt {
+                author_id,
+                salt: encoded_generated_salt.as_str(),
+            };
+            diesel::insert_into(salts::table)
+                .values(new_salt)
+                .execute(conn)?;
+
+            // TODO (hirevo): implement team membership verification (as an option).
+            // TODO (hirevo): implement organization membership verification (as an option).
+
+            author_id
+        } else {
+            return utils::response::error_html(
+                req.state(),
+                None,
+                StatusCode::NotFound,
+                "user registration is forbidden for this instance",
+            );
+        };
+
+        //? Get the maximum duration of the session.
+        let expiry = Duration::from_secs(86_400); // 1 day / 24 hours
+
+        //? Set the user's session.
+        req.session_mut().insert("author.id", author_id)?;
+        req.session_mut().expire_in(expiry);
+
+        return Ok(utils::response::redirect("/"));
+    });
+
+    transaction.await
+}
+
+async fn check_memberships(
+    origin: &Url,
+    allowed_groups: &[String],
+    client: &reqwest::Client,
+    token: &AccessToken,
+) -> tide::Result<bool> {
+    let mut request_url = origin.clone();
+    request_url.set_path("/api/v4/groups");
+
+    let mut next = Some(request_url);
+    while let Some(url) = next {
+        let response = client
+            .get(url)
+            .bearer_auth(token.secret().clone())
+            .send()
+            .await?
+            .error_for_status()?;
+
+        next = (|| {
+            let value = response.headers().get("Link")?;
+            let value = value.to_str().ok()?;
+            let captures = LINK_HEADER_REGEX.captures(value)?;
+            let capture = captures.get(1)?;
+            let capture = Url::parse(capture.as_str()).ok()?;
+            Some(capture)
+        })();
+
+        let groups: Vec<GitlabGroup> = response.json().await?;
+
+        let allowed = groups
+            .iter()
+            .any(|it| allowed_groups.contains(&it.full_path));
+
+        if allowed {
+            return Ok(true);
+        }
+    }
+
+    Ok(false)
+}

--- a/crates/alexandrie/src/frontend/account/gitlab/detach.rs
+++ b/crates/alexandrie/src/frontend/account/gitlab/detach.rs
@@ -1,0 +1,26 @@
+use diesel::prelude::*;
+use tide::Request;
+
+use crate::db::schema::authors;
+use crate::utils;
+use crate::utils::auth::AuthExt;
+use crate::State;
+
+pub(crate) async fn get(req: Request<State>) -> tide::Result {
+    let author = match req.get_author() {
+        Some(author) => author,
+        None => {
+            return Ok(utils::response::redirect("/account/manage"));
+        }
+    };
+
+    (req.state().db)
+        .run(move |conn| {
+            diesel::update(authors::table.find(author.id))
+                .set(authors::gitlab_id.eq(None::<String>))
+                .execute(conn)
+        })
+        .await?;
+
+    Ok(utils::response::redirect("/account/manage"))
+}

--- a/crates/alexandrie/src/frontend/account/gitlab/detach.rs
+++ b/crates/alexandrie/src/frontend/account/gitlab/detach.rs
@@ -1,18 +1,25 @@
 use diesel::prelude::*;
-use tide::Request;
+use tide::{Request, StatusCode};
 
 use crate::db::schema::authors;
+use crate::frontend::account::utils::count_auth_methods;
 use crate::utils;
 use crate::utils::auth::AuthExt;
 use crate::State;
 
 pub(crate) async fn get(req: Request<State>) -> tide::Result {
-    let author = match req.get_author() {
-        Some(author) => author,
-        None => {
-            return Ok(utils::response::redirect("/account/manage"));
-        }
+    let Some(author) = req.get_author() else {
+        return Ok(utils::response::redirect("/account/manage"));
     };
+
+    if count_auth_methods(&author) < 2 {
+        return utils::response::error_html(
+            req.state(),
+            Some(author),
+            StatusCode::BadRequest,
+            "too few authentication methods remaining",
+        );
+    }
 
     (req.state().db)
         .run(move |conn| {

--- a/crates/alexandrie/src/frontend/account/gitlab/mod.rs
+++ b/crates/alexandrie/src/frontend/account/gitlab/mod.rs
@@ -1,0 +1,53 @@
+use oauth2::{CsrfToken, Scope};
+use serde::{Deserialize, Serialize};
+use tide::{Request, StatusCode};
+
+/// Callback endpoint for the "gitlab" authentication strategy.
+pub mod callback;
+/// Endpoint to attach to an existing Alexandrie account.
+pub mod attach;
+/// Endpoint to detach from an existing Alexandrie account.
+pub mod detach;
+
+use crate::utils;
+use crate::utils::auth::AuthExt;
+use crate::utils::response::common;
+use crate::State;
+
+const GITLAB_LOGIN_STATE_KEY: &str = "login.gitlab";
+
+#[derive(Clone, Serialize, Deserialize)]
+struct GitlabLoginState {
+    state: CsrfToken,
+    attach: bool,
+}
+
+pub(crate) async fn get(mut req: Request<State>) -> tide::Result {
+    if let Some(author) = req.get_author() {
+        let state = req.state().as_ref();
+        return common::already_logged_in(state, author);
+    }
+
+    let gitlab_state = match req.state().frontend.auth.gitlab.as_ref() {
+        Some(state) => state,
+        None => {
+            return utils::response::error_html(
+                req.state(),
+                None,
+                StatusCode::BadRequest,
+                "authentication using GitLab is not allowed on this instance",
+            );
+        }
+    };
+
+    let (url, state) = gitlab_state
+        .client
+        .authorize_url(CsrfToken::new_random)
+        .add_scope(Scope::new("read_api".to_string()))
+        .url();
+
+    let data = GitlabLoginState { state, attach: false };
+    req.session_mut().insert(GITLAB_LOGIN_STATE_KEY, &data)?;
+
+    return Ok(utils::response::redirect(url.as_str()));
+}

--- a/crates/alexandrie/src/frontend/account/gitlab/mod.rs
+++ b/crates/alexandrie/src/frontend/account/gitlab/mod.rs
@@ -2,10 +2,10 @@ use oauth2::{CsrfToken, Scope};
 use serde::{Deserialize, Serialize};
 use tide::{Request, StatusCode};
 
-/// Callback endpoint for the "gitlab" authentication strategy.
-pub mod callback;
 /// Endpoint to attach to an existing Alexandrie account.
 pub mod attach;
+/// Callback endpoint for the "gitlab" authentication strategy.
+pub mod callback;
 /// Endpoint to detach from an existing Alexandrie account.
 pub mod detach;
 
@@ -46,7 +46,10 @@ pub(crate) async fn get(mut req: Request<State>) -> tide::Result {
         .add_scope(Scope::new("read_api".to_string()))
         .url();
 
-    let data = GitlabLoginState { state, attach: false };
+    let data = GitlabLoginState {
+        state,
+        attach: false,
+    };
     req.session_mut().insert(GITLAB_LOGIN_STATE_KEY, &data)?;
 
     return Ok(utils::response::redirect(url.as_str()));

--- a/crates/alexandrie/src/frontend/account/manage/passwd.rs
+++ b/crates/alexandrie/src/frontend/account/manage/passwd.rs
@@ -100,17 +100,16 @@ pub(crate) async fn post(mut req: Request<State>) -> tide::Result {
                 Ok((fst, snd))
             })();
 
-            let (decoded_current_password, decoded_expected_hash) =
-                match decode_results {
-                    Ok(results) => results,
-                    Err(_) => {
-                        let message = String::from("password/salt decoding issue.");
-                        let flash_message = ManageFlashMessage::PasswordChangeError { message };
-                        req.session_mut()
-                            .insert(ACCOUNT_MANAGE_FLASH, &flash_message)?;
-                        return Ok(utils::response::redirect("/account/manage"));
-                    }
-                };
+            let (decoded_current_password, decoded_expected_hash) = match decode_results {
+                Ok(results) => results,
+                Err(_) => {
+                    let message = String::from("password/salt decoding issue.");
+                    let flash_message = ManageFlashMessage::PasswordChangeError { message };
+                    req.session_mut()
+                        .insert(ACCOUNT_MANAGE_FLASH, &flash_message)?;
+                    return Ok(utils::response::redirect("/account/manage"));
+                }
+            };
 
             //? Verify client password against the expected hash (through PBKDF2).
             let password_match = {

--- a/crates/alexandrie/src/frontend/account/mod.rs
+++ b/crates/alexandrie/src/frontend/account/mod.rs
@@ -6,3 +6,7 @@ pub mod logout;
 pub mod manage;
 /// Account registration pages (eg. "/account/register").
 pub mod register;
+/// Authentication using `github` (eg. "/account/github")
+pub mod github;
+/// Authentication using `gitlab` (eg. "/account/gitlab")
+pub mod gitlab;

--- a/crates/alexandrie/src/frontend/account/mod.rs
+++ b/crates/alexandrie/src/frontend/account/mod.rs
@@ -1,3 +1,7 @@
+/// Authentication using `github` (eg. "/account/github")
+pub mod github;
+/// Authentication using `gitlab` (eg. "/account/gitlab")
+pub mod gitlab;
 /// Account login pages (eg. "/account/login").
 pub mod login;
 /// Account logout page (eg. "/account/logout").
@@ -6,7 +10,3 @@ pub mod logout;
 pub mod manage;
 /// Account registration pages (eg. "/account/register").
 pub mod register;
-/// Authentication using `github` (eg. "/account/github")
-pub mod github;
-/// Authentication using `gitlab` (eg. "/account/gitlab")
-pub mod gitlab;

--- a/crates/alexandrie/src/frontend/account/mod.rs
+++ b/crates/alexandrie/src/frontend/account/mod.rs
@@ -10,3 +10,5 @@ pub mod logout;
 pub mod manage;
 /// Account registration pages (eg. "/account/register").
 pub mod register;
+/// Various auth-related utility functions.
+pub mod utils;

--- a/crates/alexandrie/src/frontend/account/utils.rs
+++ b/crates/alexandrie/src/frontend/account/utils.rs
@@ -1,0 +1,20 @@
+use crate::db::models::Author;
+
+/// Returns the number of authentication methods available for this crate author.
+pub fn count_auth_methods(author: &Author) -> usize {
+    let mut count = 0;
+
+    if author.passwd.is_some() {
+        count += 1;
+    }
+
+    if author.github_id.is_some() {
+        count += 1;
+    }
+
+    if author.gitlab_id.is_some() {
+        count += 1;
+    }
+
+    count
+}

--- a/crates/alexandrie/src/main.rs
+++ b/crates/alexandrie/src/main.rs
@@ -114,6 +114,30 @@ fn frontend_routes(state: State, frontend_config: FrontendConfig) -> io::Result<
     app.at("/account/register")
         .get(frontend::account::register::get)
         .post(frontend::account::register::post);
+    log::info!("mounting '/account/github'");
+    app.at("/account/github")
+        .get(frontend::account::github::get);
+    log::info!("mounting '/account/github/attach'");
+    app.at("/account/github/attach")
+        .get(frontend::account::github::attach::get);
+    log::info!("mounting '/account/github/detach'");
+    app.at("/account/github/detach")
+        .get(frontend::account::github::detach::get);
+    log::info!("mounting '/account/github/callback'");
+    app.at("/account/github/callback")
+        .get(frontend::account::github::callback::get);
+    log::info!("mounting '/account/gitlab'");
+    app.at("/account/gitlab")
+        .get(frontend::account::gitlab::get);
+    log::info!("mounting '/account/gitlab/attach'");
+    app.at("/account/gitlab/attach")
+        .get(frontend::account::gitlab::attach::get);
+    log::info!("mounting '/account/gitlab/detach'");
+    app.at("/account/gitlab/detach")
+        .get(frontend::account::gitlab::detach::get);
+    log::info!("mounting '/account/gitlab/callback'");
+    app.at("/account/gitlab/callback")
+        .get(frontend::account::gitlab::callback::get);
     log::info!("mounting '/account/manage'");
     app.at("/account/manage")
         .get(frontend::account::manage::get);

--- a/docker/mysql/alexandrie.toml
+++ b/docker/mysql/alexandrie.toml
@@ -23,6 +23,13 @@ path = "assets"
 [frontend.templates]
 path = "templates"
 
+[frontend.auth]
+origin = "http://localhost:3000"
+
+[frontend.auth.local]
+enabled = true
+allow_registration = true
+
 [database]
 # note that 'mysqldb' is the name of the container in the mysql-compose file, and
 # is automatically populated in the hosts file by docker

--- a/docker/postgres/alexandrie.toml
+++ b/docker/postgres/alexandrie.toml
@@ -23,6 +23,13 @@ path = "assets"
 [frontend.templates]
 path = "templates"
 
+[frontend.auth]
+origin = "http://localhost:3000"
+
+[frontend.auth.local]
+enabled = true
+allow_registration = true
+
 [database]
 url = "postgresql://root:root@postgresqldb:5432/alexandrie"
 

--- a/docker/sqlite/alexandrie.toml
+++ b/docker/sqlite/alexandrie.toml
@@ -23,6 +23,13 @@ path = "assets"
 [frontend.templates]
 path = "templates"
 
+[frontend.auth]
+origin = "http://localhost:3000"
+
+[frontend.auth.local]
+enabled = true
+allow_registration = true
+
 [database]
 url = "appdata/sqlite/alexandrie.db"
 

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -11,6 +11,7 @@ Summary
   - [Index management strategies](./whats-available/index-management-strategies.md)
   - [Crate stores](./whats-available/crate-stores.md)
   - [Docker](./whats-available/docker.md)
+  - [Authentication Strategies](./whats-available/authentication-strategies.md)
 - [Programmatic API](./programmatic-api/mod.md)
   - [Authentication](./programmatic-api/authentication.md)
   - [Account Management section](./programmatic-api/account/mod.md)

--- a/docs/src/whats-available/authentication-strategies.md
+++ b/docs/src/whats-available/authentication-strategies.md
@@ -1,0 +1,84 @@
+Authentication Strategies
+=========================
+
+Alexandrie supports authenticating using various methods and services.  
+
+Here are the details about the various means of authentication you can use in Alexandrie.
+
+> All of these authentication means currently only apply to the frontend.  
+> The programmatic API for Alexandrie already uses its own token system for authorization.  
+
+Local
+-----
+
+This strategy is the regular email/password combination flow that is already in place, using the input forms.  
+This can be disabled, in case you want to exclusively use an alternative authentication strategy, for example.
+
+Configuration:
+
+```toml
+# Omitting this entire section from the configuration counts as being disabled.
+[frontend.auth.local]
+# Whether to enable the use of this strategy.
+enable = true
+# Whether to allow the registration of new users using this strategy.
+allow_registration = true
+```
+
+GitHub
+------
+
+This strategy uses OAuth 2 to authenticate the user using its GitHub account.  
+Filters on who gets authorized can be added based on organization or team membership.  
+
+Configuration:
+
+```toml
+# Omitting this entire section from the configuration counts as being disabled.
+[frontend.auth.github]
+# Whether to enable the use of this strategy.
+enable = true
+# The client ID of the GitHub OAuth App to use.
+client_id = "GITHUB_OAUTH_CLIENT_ID"
+# The client secret of the GitHub OAuth App to use.
+client_secret = "GITHUB_OAUTH_CLIENT_SECRET"
+# The organizations of which membership in one of them is required to be authorized.
+# Omit `allowed_organizations` to not require any organization membership.
+allowed_organizations = [
+    # Being a member of this organization will be sufficient to be authorized.
+    { name = "ORG_NAME_1" },
+    # But being a member of this one additionally requires membership in one of the specified teams withing that organization.
+    { name = "ORG_NAME_2", allowed_teams = ["TEAM_NAME"] },
+]
+# Whether to allow the registration of new users using this strategy.
+allow_registration = true
+```
+
+GitLab
+------
+
+This uses OAuth 2 to authenticate the user using its GitLab account.  
+The remote instance can either be the [public one](https://gitlab.com) or a private instance.  
+Filters on who gets authorized can be added based on group membership.  
+
+Configuration:
+
+```toml
+# Omitting this entire section from the configuration counts as being disabled.
+[frontend.auth.gitlab]
+# Whether to enable the use of this strategy.
+enable = true
+# The client ID of the GitLab OAuth App to use.
+client_id = "GITLAB_OAUTH_CLIENT_ID"
+# The client secret of the GitLab OAuth App to use.
+client_secret = "GITLAB_OAUTH_CLIENT_SECRET"
+# The groups of which membership in one of them is required to be authorized.
+# Omit `allowed_groups` to not require any group membership.
+allowed_groups = [
+    "GROUP_NAME_1",
+    # subgroups are specified by their full paths, like this.
+    "GROUP_NAME_2/SUBGROUP_NAME_1",
+]
+# Whether to allow the registration of new users using this strategy.
+allow_registration = true
+```

--- a/docs/src/whats-available/authentication-strategies.md
+++ b/docs/src/whats-available/authentication-strategies.md
@@ -29,7 +29,19 @@ GitHub
 ------
 
 This strategy uses OAuth 2 to authenticate the user using its GitHub account.  
-Filters on who gets authorized can be added based on organization or team membership.  
+Filters on who gets authorized can be added based on organization or team membership.
+
+You'll need to create a GitHub OAuth App in order to get the required OAuth client credentials (the replacements for `GITHUB_OAUTH_CLIENT_ID` and `GITHUB_OAUTH_CLIENT_SECRET` in the example below) necessary for Alexandrie to authenticate users.
+
+You can create a new GitHub OAuth App by [**clicking here (for github.com)**](https://github.com/settings/applications/new).  
+You can also simply find it in your account settings, under `Developer Settings` > `OAuth Apps` and clicking on the `New OAuth App` button.
+
+The homepage URL to use is simply the URL to your Alexandrie instance's homepage.  
+The authorization callback URL to use is the homepage URL with `/account/github/callback` added.
+
+For example, in the case of the Alexandrie instance hosted at **<https://crates.polomack.eu>**:
+- the homepage URL is `https://crates.polomack.eu`.
+- the authorization callback URL is `https://crates.polomack.eu/account/github/callback`.
 
 Configuration:
 
@@ -60,6 +72,18 @@ GitLab
 This uses OAuth 2 to authenticate the user using its GitLab account.  
 The remote instance can either be the [public one](https://gitlab.com) or a private instance.  
 Filters on who gets authorized can be added based on group membership.  
+
+You'll need to create a GitLab Application in order to get the required OAuth client credentials (the replacements for `GITLAB_OAUTH_CLIENT_ID` and `GITLAB_OAUTH_CLIENT_SECRET` in the example below) necessary for Alexandrie to authenticate users.
+
+You can create a new GitLab Application by [**clicking here (for gitlab.com)**](https://gitlab.com/-/profile/applications).  
+You can also simply find this page within your account settings, under section `Applications`.  
+
+The authorization callback URL to use is the homepage URL with `/account/gitlab/callback` added.
+
+For example, in the case of the Alexandrie instance hosted at **<https://crates.polomack.eu>**:
+- the authorization callback URL is `https://crates.polomack.eu/account/gitlab/callback`.
+
+The only OAuth scope needed to be granted for Alexandrie's usage is `read_api`.
 
 Configuration:
 

--- a/migrations/mysql/2021-10-12-215020_external_auth/down.sql
+++ b/migrations/mysql/2021-10-12-215020_external_auth/down.sql
@@ -1,0 +1,2 @@
+alter table `authors` drop column `github_id`;
+alter table `authors` drop column `gitlab_id`;

--- a/migrations/mysql/2021-10-12-215020_external_auth/down.sql
+++ b/migrations/mysql/2021-10-12-215020_external_auth/down.sql
@@ -1,2 +1,3 @@
 alter table `authors` drop column `github_id`;
 alter table `authors` drop column `gitlab_id`;
+alter table `authors` modify column `passwd` varchar(255) unique;

--- a/migrations/mysql/2021-10-12-215020_external_auth/up.sql
+++ b/migrations/mysql/2021-10-12-215020_external_auth/up.sql
@@ -1,0 +1,3 @@
+alter table `authors` add column `github_id` varchar(255) unique;
+alter table `authors` add column `gitlab_id` varchar(255) unique;
+alter table `authors` modify column `passwd` varchar(255);

--- a/migrations/postgres/2021-10-12-215020_external_auth/down.sql
+++ b/migrations/postgres/2021-10-12-215020_external_auth/down.sql
@@ -1,0 +1,1 @@
+-- This file should undo anything in `up.sql`

--- a/migrations/postgres/2021-10-12-215020_external_auth/down.sql
+++ b/migrations/postgres/2021-10-12-215020_external_auth/down.sql
@@ -1,1 +1,3 @@
--- This file should undo anything in `up.sql`
+alter table "authors" drop column "github_id";
+alter table "authors" drop column "gitlab_id";
+alter table "authors" alter column "passwd" varchar(255) unique;

--- a/migrations/postgres/2021-10-12-215020_external_auth/down.sql
+++ b/migrations/postgres/2021-10-12-215020_external_auth/down.sql
@@ -1,3 +1,4 @@
 alter table "authors" drop column "github_id";
 alter table "authors" drop column "gitlab_id";
 alter table "authors" alter column "passwd" varchar(255) unique;
+alter table "authors" alter column "passwd" set not null;

--- a/migrations/postgres/2021-10-12-215020_external_auth/up.sql
+++ b/migrations/postgres/2021-10-12-215020_external_auth/up.sql
@@ -1,0 +1,3 @@
+alter table `authors` add column `github_id` varchar(255) unique;
+alter table `authors` add column `gitlab_id` varchar(255) unique;
+alter table `authors` modify column `passwd` varchar(255);

--- a/migrations/postgres/2021-10-12-215020_external_auth/up.sql
+++ b/migrations/postgres/2021-10-12-215020_external_auth/up.sql
@@ -1,3 +1,3 @@
-alter table `authors` add column `github_id` varchar(255) unique;
-alter table `authors` add column `gitlab_id` varchar(255) unique;
-alter table `authors` modify column `passwd` varchar(255);
+alter table "authors" add column "github_id" varchar(255) unique;
+alter table "authors" add column "gitlab_id" varchar(255) unique;
+alter table "authors" alter column "passwd" type varchar(255);

--- a/migrations/postgres/2021-10-12-215020_external_auth/up.sql
+++ b/migrations/postgres/2021-10-12-215020_external_auth/up.sql
@@ -1,3 +1,4 @@
 alter table "authors" add column "github_id" varchar(255) unique;
 alter table "authors" add column "gitlab_id" varchar(255) unique;
 alter table "authors" alter column "passwd" type varchar(255);
+alter table "authors" alter column "passwd" drop not null;

--- a/migrations/sqlite/2021-10-12-215020_external_auth/down.sql
+++ b/migrations/sqlite/2021-10-12-215020_external_auth/down.sql
@@ -1,0 +1,1 @@
+-- This file should undo anything in `up.sql`

--- a/migrations/sqlite/2021-10-12-215020_external_auth/down.sql
+++ b/migrations/sqlite/2021-10-12-215020_external_auth/down.sql
@@ -1,1 +1,10 @@
--- This file should undo anything in `up.sql`
+alter table `authors` rename to `authors_old`;
+create table `authors` (
+    `id` integer primary key,
+    `email` varchar(255) not null unique,
+    `name` varchar(255) not null,
+    `passwd` varchar(255) unique,
+);
+insert into `authors` (`id`, `email`, `name`, `passwd`)
+    select `id`, `email`, `name`, `passwd` from `authors_old`;
+drop table `authors_old`;

--- a/migrations/sqlite/2021-10-12-215020_external_auth/up.sql
+++ b/migrations/sqlite/2021-10-12-215020_external_auth/up.sql
@@ -1,0 +1,12 @@
+alter table `authors` rename to `authors_old`;
+create table `authors` (
+    `id` integer primary key,
+    `email` varchar(255) not null unique,
+    `name` varchar(255) not null,
+    `passwd` varchar(255),
+    `github_id` varchar(255) unique,
+    `gitlab_id` varchar(255) unique
+);
+insert into `authors` (`id`, `email`, `name`, `passwd`)
+    select `id`, `email`, `name`, `passwd` from `authors_old`;
+drop table `authors_old`;

--- a/templates/account/login.hbs
+++ b/templates/account/login.hbs
@@ -53,22 +53,32 @@
             border-bottom: 2px solid var(--fg-color);
         }
 
-        .login-container {
+        .page-container {
             width: 100%;
             display: flex;
             align-items: center;
             justify-content: center;
+        }
+
+        .login-container {
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            flex-direction: column;
+            gap: 10px;
+            margin: 10px;
             font-size: 17px;
+            width: 100%;
+            max-width: 450px;
         }
 
         .login-content {
             width: 100%;
-            max-width: 430px;
             display: flex;
             align-items: center;
             justify-content: flex-start;
             flex-direction: column;
-            padding: 10px;
+            gap: 10px;
         }
 
         @media (max-width: 1400px) {
@@ -85,11 +95,6 @@
             display: flex;
             flex-direction: column;
             width: 100%;
-            padding: 5px 0;
-        }
-
-        .login-field:first-child {
-            padding-top: 0;
         }
 
         .login-checkbox-field {
@@ -102,7 +107,7 @@
         }
 
         .login-checkbox-label {
-            padding: 5px 0;
+            font-weight: bold;
         }
 
         .login-input {
@@ -113,12 +118,13 @@
             padding: 7px 10px;
             color: var(--fg-color);
             background: transparent;
+            font: inherit;
             font-size: 16px;
             font-weight: 600;
-            font-family: "Fira Sans", sans-serif;
             border-radius: 5px;
             border: solid 2px var(--darker-bg-color);
             transition: border-color 0.15s;
+            margin: 0;
         }
 
         .login-input:focus {
@@ -134,15 +140,6 @@
             position: relative;
             vertical-align: middle;
             bottom: 1px;
-        }
-
-        .login-buttons {
-            display: grid;
-            grid-template-rows: 1fr 1fr;
-            grid-template-columns: 1fr;
-            grid-gap: 10px;
-            width: 100%;
-            padding-top: 5px;
         }
 
         .login-button {
@@ -163,6 +160,8 @@
             display: flex;
             align-items: center;
             justify-content: center;
+            margin: 0;
+            width: 100%;
         }
 
         .login-button:hover,
@@ -177,6 +176,10 @@
             cursor: default;
         }
 
+        .login-link {
+            width: 100%;
+        }
+
         .login-error-msg {
             padding: 10px;
             background-color: var(--danger-bg-color);
@@ -184,6 +187,26 @@
             border-radius: 5px;
             margin: 5px 0;
             font-weight: bold;
+        }
+
+        .form-separator-container {
+            display: grid;
+            grid-gap: 10px;
+            grid-template-rows: 1fr;
+            grid-template-columns: 1fr min-content 1fr;
+            width: 100%;
+            align-items: center;
+            justify-content: center;
+        }
+
+        .form-separator {
+            height: 2px;
+            width: 100%;
+            background-color: var(--fg-color);
+        }
+
+        .form-separator-text {
+            font-weight: 800;
         }
 
         @media (prefers-color-scheme: dark) {
@@ -218,32 +241,55 @@
             <div class="separator"></div>
         </div>
     </div>
-    <div class="login-container">
-        <form class="login-content" method="POST" action="/account/login">
-            <div class="login-field">
-                <label class="login-label" for="email">Email:</label>
-                <input class="login-input" type="email" name="email" id="email" placeholder="Enter email..." autocomplete="email" required>
-            </div>
-            <div class="login-field">
-                <label class="login-label" for="password">Password:</label>
-                <input class="login-input" type="password" name="password" id="password" placeholder="Enter password..." autocomplete="current-password" required>
-            </div>
-            <div class="login-field login-checkbox-field">
-                <label class="login-label login-checkbox-label">
-                    <input class="login-checkbox" type="checkbox" name="remember">
-                    Remember me for 30 days
-                </label>
-            </div>
-            {{#if (equal flash.kind "error")}}
-            <div class="login-field login-error-msg">
-                Error: {{ flash.message }}
+    <div class="page-container">
+        <div class="login-container">
+            {{#if (equal local_enabled true)}}
+            <form class="login-content" method="POST" action="/account/login">
+                <div class="login-field">
+                    <label class="login-label" for="email">Email:</label>
+                    <input class="login-input" type="email" name="email" id="email" placeholder="Enter email..." autocomplete="email" required>
+                </div>
+                <div class="login-field">
+                    <label class="login-label" for="password">Password:</label>
+                    <input class="login-input" type="password" name="password" id="password" placeholder="Enter password..." autocomplete="current-password" required>
+                </div>
+                <div class="login-field login-checkbox-field">
+                    <label class="login-checkbox-label">
+                        <input class="login-checkbox" type="checkbox" name="remember">
+                        Remember me for 30 days
+                    </label>
+                </div>
+                {{#if (equal flash.kind "error")}}
+                <div class="login-field login-error-msg">
+                    Error: {{ flash.message }}
+                </div>
+                {{/if}}
+                <input type="submit" value="Log in" class="login-button">
+                {{#if (equal local_allowed_registration "true")}}
+                <a class="login-link" href="/account/register">
+                    <div class="login-button">Need to create an account ?</div>
+                </a>
+                {{/if}}
+            </form>
+            {{/if}}
+            {{#if (equal has_separator true)}}
+            <div class="form-separator-container">
+                <div class="form-separator"></div>
+                <div class="form-separator-text">OR</div>
+                <div class="form-separator"></div>
             </div>
             {{/if}}
-            <div class="login-buttons">
-                <input type="submit" value="Log in" class="login-button">
-                <a href="/account/register" class="login-button">Need to create an account ?</a>
-            </div>
-        </form>
+            {{#if (equal github_enabled true)}}
+            <a class="login-link" href="/account/github">
+                <div class="login-button">Log in with GitHub</div>
+            </a>
+            {{/if}}
+            {{#if (equal gitlab_enabled true)}}
+            <a class="login-link" href="/account/gitlab">
+                <div class="login-button">Log in with GitLab</div>
+            </a>
+            {{/if}}
+        </div>
     </div>
     <script type="module">
         import init, * as Rust from "/assets/wasm/wasm_pbkdf2.js";

--- a/templates/account/manage.hbs
+++ b/templates/account/manage.hbs
@@ -408,6 +408,10 @@
                 background-color: var(--dark-fg-color);
                 color: var(--bg-color);
             }
+            
+            .grouped-label, .grouped-button {
+                border-color: var(--darker-fg-color);
+            }
         }
     </style>
 </head>

--- a/templates/account/manage.hbs
+++ b/templates/account/manage.hbs
@@ -71,7 +71,7 @@
             padding: 10px;
             display: grid;
             grid-template-rows: 1fr;
-            grid-template-columns: repeat(2, 1fr);
+            grid-template-columns: 1fr 2px 1fr 2px 1fr;
             align-items: center;
             justify-content: center;
         }
@@ -108,16 +108,9 @@
             padding: 10px 20px;
         }
 
-        .manage-passwd {
-            border-right: 1px solid var(--fg-color);
-        }
-
-        .manage-tokens {
-            border-left: 1px solid var(--fg-color);
-        }
-
         .manage-passwd-title,
-        .manage-tokens-title {
+        .manage-tokens-title,
+        .manage-accounts-title {
             width: 100%;
             text-align: center;
             font-size: 21px;
@@ -230,60 +223,12 @@
 
         .manage-tokens-entries {
             width: 100%;
-            counter-reset: rank;
             display: flex;
             flex-direction: column;
-            padding: 10px 0;
-        }
-
-        .manage-tokens-entry {
-            font-weight: bold;
-            display: grid;
-            grid-template-columns: min-content min-content;
-            grid-template-rows: min-content;
-            margin-top: 5px;
-        }
-
-        .manage-tokens-entry:first-child {
-            margin-top: 0;
-        }
-
-        .manage-tokens-entry-name {
-            width: 100%;
-            height: 100%;
-            display: flex;
-            align-items: center;
+            align-items: flex-start;
             justify-content: flex-start;
-            white-space: nowrap;
-            padding: 5px 10px;
-            border-radius: 5px 0 0 5px;
-            border: 2px solid var(--darker-bg-color);
-            border-right: none;
-            background-color: var(--dark-bg-color);
-        }
-
-        .manage-tokens-entry-revoke {
-            cursor: pointer;
-            font-weight: bold;
-            text-align: center;
-            padding: 3px 10px;
-            transition: background-color 0.15s, border-color 0.15s;
-            display: flex;
-            align-items: center;
-            justify-content: center;
-            border-radius: 0 5px 5px 0;
-            border: 2px solid var(--darker-bg-color);
-        }
-
-        .manage-tokens-entry-revoke:hover,
-        .manage-tokens-entry-revoke:focus {
-            border: 2px solid var(--fg-color);
-            background-color: var(--dark-bg-color);
-        }
-
-        .manage-tokens-entry-revoke::before {
-            font-family: alexicons;
-            /* content: "\e901"; */
+            gap: 5px;
+            padding: 10px 0;
         }
 
         .manage-tokens-empty {
@@ -321,9 +266,105 @@
             font-weight: bold;
         }
 
+        .separator-container {
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            width: 100%;
+            height: 100%;
+        }
+
+        .separator {
+            background-color: var(--fg-color);
+            width: 90vw;
+            height: 100%;
+        }
+
+        .manage-accounts {
+            width: 100%;
+            height: 100%;
+            display: flex;
+            align-items: center;
+            justify-content: flex-start;
+            flex-direction: column;
+            padding: 10px 20px;
+        }
+
+        .manage-accounts-content {
+            width: 100%;
+            height: 100%;
+            display: flex;
+            align-items: center;
+            justify-content: space-evenly;
+            flex-direction: column;
+            gap: 10px;
+        }
+
+        .manage-accounts-section {
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            flex-direction: column;
+            gap: 5px;
+        }
+
+        .manage-accounts-section-title {
+            font-weight: bold;
+            text-align: center;
+        }
+
+        .grouped {
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            flex-wrap: nowrap;
+            white-space: nowrap;
+            font-weight: bold;
+            text-align: center;
+        }
+
+        .grouped > * {
+            padding: 5px 10px;
+            border: 2px solid;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+        }
+
+        .grouped > *:first-child {
+            border-radius: 5px 0 0 5px;
+        }
+
+        .grouped > *:last-child {
+            border-radius: 0 5px 5px 0;
+        }
+
+        .grouped > *:not(:last-child) {
+            margin-right: -2px;
+        }
+
+        .grouped-label {
+            color: var(--fg-color);
+            border-color: var(--darker-bg-color);
+            background-color: var(--dark-bg-color);
+        }
+
+        .grouped-button {
+            cursor: pointer;
+            transition: background-color 0.15s, border-color 0.15s;
+            border-color: var(--darker-bg-color);
+        }
+
+        .grouped-button:hover,
+        .grouped-button:focus {
+            z-index: 2;
+            border-color: var(--fg-color);
+            background-color: var(--dark-bg-color);
+        }
+
         @media (max-width: 1000px) {
             .manage-grid {
-                grid-template-rows: repeat(2, min-content);
+                grid-template-rows: min-content 2px min-content 2px min-content;
                 grid-template-columns: 1fr;
             }
 
@@ -359,7 +400,6 @@
             .manage-tokens-entry-revoke {
                 border-color: var(--darker-fg-color);
             }
-
 
             .manage-passwd-button:disabled,
             .manage-tokens-button:disabled,
@@ -422,14 +462,39 @@
                     </div>
                     <input class="manage-passwd-button" type="submit" value="Change password">
                 </form>
+                <div class="separator-container">
+                    <div class="separator"></div>
+                </div>
+                <div class="manage-accounts">
+                    <div class="manage-accounts-title">External Accounts</div>
+                    <div class="manage-accounts-content">
+                        <div class="manage-accounts-section">
+                            <div class="manage-accounts-section-title">Currently attached services:</div>
+                            <div class="grouped">
+                                <div class="grouped-label">GitHub</div>
+                                <a class="grouped-button" href="/account/github/detach">Detach</a>
+                            </div>
+                        </div>
+                        <div class="manage-accounts-section">
+                            <div class="manage-accounts-section-title">Services available to attach:</div>
+                            <div class="grouped">
+                                <div class="grouped-label">GitLab</div>
+                                <a class="grouped-button" href="/account/github/attach">Attach</a>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+                <div class="separator-container">
+                    <div class="separator"></div>
+                </div>
                 <div class="manage-tokens">
                     <div class="manage-tokens-title">Tokens</div>
                     <div class="manage-tokens-entries">
                         {{#if tokens}}
                         {{#each tokens}}
-                        <div class="manage-tokens-entry">
-                            <div class="manage-tokens-entry-name">{{ this.name }}</div>
-                            <a class="manage-tokens-entry-revoke" href="/account/manage/tokens/{{ this.id }}/revoke">Revoke</a>
+                        <div class="grouped">
+                            <div class="grouped-label">{{ this.name }}</div>
+                            <a class="grouped-button" href="/account/manage/tokens/{{ this.id }}/revoke">Revoke</a>
                         </div>
                         {{/each}}
                         {{else}}

--- a/templates/account/manage.hbs
+++ b/templates/account/manage.hbs
@@ -408,7 +408,7 @@
                 background-color: var(--dark-fg-color);
                 color: var(--bg-color);
             }
-            
+
             .grouped-label, .grouped-button {
                 border-color: var(--darker-fg-color);
             }
@@ -474,17 +474,33 @@
                     <div class="manage-accounts-content">
                         <div class="manage-accounts-section">
                             <div class="manage-accounts-section-title">Currently attached services:</div>
+                            {{#if author.github_id}}
                             <div class="grouped">
                                 <div class="grouped-label">GitHub</div>
                                 <a class="grouped-button" href="/account/github/detach">Detach</a>
                             </div>
+                            {{/if}}
+                            {{#if author.gitlab_id}}
+                            <div class="grouped">
+                                <div class="grouped-label">GitLab</div>
+                                <a class="grouped-button" href="/account/gitlab/detach">Detach</a>
+                            </div>
+                            {{/if}}
                         </div>
                         <div class="manage-accounts-section">
                             <div class="manage-accounts-section-title">Services available to attach:</div>
+                            {{#unless author.github_id}}
                             <div class="grouped">
-                                <div class="grouped-label">GitLab</div>
+                                <div class="grouped-label">GitHub</div>
                                 <a class="grouped-button" href="/account/github/attach">Attach</a>
                             </div>
+                            {{/unless}}
+                            {{#unless author.gitlab_id}}
+                            <div class="grouped">
+                                <div class="grouped-label">GitLab</div>
+                                <a class="grouped-button" href="/account/gitlab/attach">Attach</a>
+                            </div>
+                            {{/unless}}
                         </div>
                     </div>
                 </div>

--- a/templates/account/register.hbs
+++ b/templates/account/register.hbs
@@ -53,7 +53,7 @@
             border-bottom: 2px solid var(--fg-color);
         }
 
-        .register-container {
+        .page-container {
             width: 100%;
             display: flex;
             align-items: center;
@@ -61,14 +61,25 @@
             font-size: 17px;
         }
 
+        .register-container {
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            flex-direction: column;
+            gap: 10px;
+            margin: 10px;
+            font-size: 17px;
+            width: 100%;
+            max-width: 450px;
+        }
+
         .register-content {
             width: 100%;
-            max-width: 430px;
             display: flex;
             align-items: center;
             justify-content: flex-start;
             flex-direction: column;
-            padding: 10px;
+            gap: 10px;
         }
 
         @media (max-width: 1400px) {
@@ -85,11 +96,6 @@
             display: flex;
             flex-direction: column;
             width: 100%;
-            padding: 5px 0;
-        }
-
-        .register-field:first-child {
-            padding-top: 0;
         }
 
         .register-checkbox-field {
@@ -102,7 +108,7 @@
         }
 
         .register-checkbox-label {
-            padding: 5px 0;
+            font-weight: bold;
         }
 
         .register-input {
@@ -113,12 +119,13 @@
             padding: 7px 10px;
             color: var(--fg-color);
             background: transparent;
+            font: inherit;
             font-size: 16px;
             font-weight: 600;
-            font-family: "Fira Sans", sans-serif;
             border-radius: 5px;
             border: solid 2px var(--darker-bg-color);
             transition: border-color 0.15s;
+            margin: 0;
         }
 
         .register-input:focus {
@@ -134,15 +141,6 @@
             position: relative;
             vertical-align: middle;
             bottom: 1px;
-        }
-
-        .register-buttons {
-            display: grid;
-            grid-template-rows: 1fr 1fr;
-            grid-template-columns: 1fr;
-            grid-gap: 10px;
-            width: 100%;
-            padding-top: 5px;
         }
 
         .register-button {
@@ -163,6 +161,8 @@
             display: flex;
             align-items: center;
             justify-content: center;
+            margin: 0;
+            width: 100%;
         }
 
         .register-button:hover,
@@ -177,6 +177,10 @@
             cursor: default;
         }
 
+        .register-link {
+            width: 100%;
+        }
+
         .register-error-msg {
             padding: 10px;
             background-color: var(--danger-bg-color);
@@ -184,6 +188,26 @@
             border-radius: 5px;
             margin: 5px 0;
             font-weight: bold;
+        }
+
+        .form-separator-container {
+            display: grid;
+            grid-gap: 10px;
+            grid-template-rows: 1fr;
+            grid-template-columns: 1fr min-content 1fr;
+            width: 100%;
+            align-items: center;
+            justify-content: center;
+        }
+
+        .form-separator {
+            height: 2px;
+            width: 100%;
+            background-color: var(--fg-color);
+        }
+
+        .form-separator-text {
+            font-weight: 800;
         }
 
         @media (prefers-color-scheme: dark) {
@@ -218,40 +242,61 @@
             <div class="separator"></div>
         </div>
     </div>
-    <div class="register-container">
-        <form class="register-content" method="POST" action="/account/register">
-            <div class="register-field">
-                <label class="register-label" for="email">Email:</label>
-                <input class="register-input" type="email" name="email" id="email" placeholder="Enter email..." autocomplete="email" required>
-            </div>
-            <div class="register-field">
-                <label class="register-label" for="name">Full name:</label>
-                <input class="register-input" type="text" name="name" id="name" placeholder="Enter full name..." autocomplete="name" required>
-            </div>
-            <div class="register-field">
-                <label class="register-label" for="password">Password:</label>
-                <input class="register-input" type="password" name="password" id="password" placeholder="Enter password..." autocomplete="new-password" required>
-            </div>
-            <div class="register-field">
-                <label class="register-label" for="confirm-password">Confirm password:</label>
-                <input class="register-input" type="password" name="confirm-password" id="confirm-password" placeholder="Confirm password..." required>
-            </div>
-            <div class="register-field register-checkbox-field">
-                <label class="register-label register-checkbox-label">
-                    <input class="register-checkbox" type="checkbox" name="remember">
-                    Remember me for 30 days
-                </label>
-            </div>
-            {{#if (equal flash.kind "error")}}
-            <div class="register-field register-error-msg">
-                Error: {{ flash.message }}
+    <div class="page-container">
+        <div class="register-container">
+            {{#if (equal local_enabled true)}}
+            <form class="register-content" method="POST" action="/account/register">
+                <div class="register-field">
+                    <label class="register-label" for="email">Email:</label>
+                    <input class="register-input" type="email" name="email" id="email" placeholder="Enter email..." autocomplete="email" required>
+                </div>
+                <div class="register-field">
+                    <label class="register-label" for="name">Full name:</label>
+                    <input class="register-input" type="text" name="name" id="name" placeholder="Enter full name..." autocomplete="name" required>
+                </div>
+                <div class="register-field">
+                    <label class="register-label" for="password">Password:</label>
+                    <input class="register-input" type="password" name="password" id="password" placeholder="Enter password..." autocomplete="new-password" required>
+                </div>
+                <div class="register-field">
+                    <label class="register-label" for="confirm-password">Confirm password:</label>
+                    <input class="register-input" type="password" name="confirm-password" id="confirm-password" placeholder="Confirm password..." required>
+                </div>
+                <div class="register-field register-checkbox-field">
+                    <label class="register-checkbox-label">
+                        <input class="register-checkbox" type="checkbox" name="remember">
+                        Remember me for 30 days
+                    </label>
+                </div>
+                {{#if (equal flash.kind "error")}}
+                <div class="register-field register-error-msg">
+                    Error: {{ flash.message }}
+                </div>
+                {{/if}}
+                <input type="submit" value="Register" class="register-button">
+                <a class="register-link" href="/account/login">
+                    <div class="register-button">Already have an account ?</div>
+                </a>
+            </form>
+            {{/if}}
+            {{#if (equal has_separator true)}}
+            <div class="form-separator-container">
+                <div class="form-separator"></div>
+                <div class="form-separator-text">OR</div>
+                <div class="form-separator"></div>
             </div>
             {{/if}}
-            <div class="register-buttons">
-                <input type="submit" value="Register" class="register-button">
-                <a href="/account/login" class="register-button">Already have an account ?</a>
-            </div>
-        </form>
+            {{#if (equal github_enabled true)}}
+            <a class="register-link" href="/account/github">
+                <div class="register-button">Register with GitHub</div>
+            </a>
+            {{/if}}
+            {{#if (equal gitlab_enabled true)}}
+            <a class="register-link" href="/account/gitlab">
+                <div class="register-button">Register with GitLab</div>
+            </a>
+            {{/if}}
+        </div>
     </div>
     <script type="module">
         import init, * as Rust from "/assets/wasm/wasm_pbkdf2.js";

--- a/templates/error.hbs
+++ b/templates/error.hbs
@@ -80,6 +80,7 @@
             border-radius: 5px;
             margin-bottom: 10px;
             font-weight: bold;
+            text-align: center;
         }
 
         @media (max-width: 1400px) {

--- a/templates/partials/head.hbs
+++ b/templates/partials/head.hbs
@@ -2,7 +2,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <meta http-equiv="X-UA-Compatible" content="ie=edge">
 <meta name="description" content="{{ instance.description }}">
-<link rel="shortcut icon" type="image/x-icon" href="{{ instance.favicon }}">
+<link rel="shortcut icon" href="{{ instance.favicon }}">
 <link rel="stylesheet" href="/assets/icons.css">
 <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Fira+Sans:400,500|Fira+Code:500">
 <title>{{ instance.title }}</title>


### PR DESCRIPTION
This PR adds support for using GitHub and/or GitLab accounts to log in and/or register to an Alexandrie instance.  

Both of these two authentication methods can be configured or disabled individually.  
The original method of authentication (the manual one, with the password form) can now also be disabled, if desired.

Existing Alexandrie accounts can also be attached/detached to/from external accounts from within the frontend's account management panel.

Here are the new pieces of configuration that this PR adds support for:

```toml
[frontend.auth.local]
enabled = true
# Set`allow_registration` to false to prevent account creation using this method.
allow_registration = true

[frontend.auth.github]
enabled = false
client_id = "GITHUB_OAUTH_CLIENT_ID"
client_secret = "GITHUB_OAUTH_CLIENT_SECRET"
# Omit `allowed_organizations` to not require any organization membership.
allowed_organizations = [
    # Using this organization does not requires any specific team membership.
    { name = "ORG_NAME_1" },
    # But using this one does requires membership in one of specified teams.
    { name = "ORG_NAME_2", allowed_teams = ["TEAM_NAME"] },
]
allow_registration = true

[frontend.auth.gitlab]
enabled = false
origin = "https://gitlab.com"
client_id = "GITLAB_OAUTH_CLIENT_ID"
client_secret = "GITLAB_OAUTH_CLIENT_SECRET"
# Omit `allowed_groups` to not require any organization membership.
allowed_groups = [
    "GROUP_1",
    "GROUP_2",
]
allow_registration = true
```