### PR TITLE
Create RPM File

### DIFF
--- a/crates/alexandrie/.rpm/alexandrie.service
+++ b/crates/alexandrie/.rpm/alexandrie.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=An alternative crate registry, implemented in Rust.
+After=network.target
+
+[Service]
+Type=simple
+ExecStart=/usr/bin/alexandrie --config /etc/alexandrie.conf
+KillMode=process
+Restart=on-failure
+User=alexandrie
+
+[Install]
+WantedBy=multi-user.target

--- a/crates/alexandrie/.rpm/alexandrie.spec
+++ b/crates/alexandrie/.rpm/alexandrie.spec
@@ -1,0 +1,61 @@
+%define __spec_install_post %{nil}
+%define __os_install_post %{_dbpath}/brp-compress
+%define debug_package %{nil}
+
+Name: alexandrie
+Summary: An alternative crate registry, implemented in Rust.
+Version: @@VERSION@@
+Release: @@RELEASE@@%{?dist}
+License: MIT or ASL 2.0
+Group: System Environment/Daemons
+Source0: %{name}-%{version}.tar.gz
+
+BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-root
+BuildRequires: systemd
+
+Requires(post): systemd
+Requires(preun): systemd
+Requires(postun): systemd
+
+%description
+%{summary}
+
+%prep
+%setup -q
+
+%install
+rm -rf %{buildroot}
+mkdir -p %{buildroot}
+cp -a * %{buildroot}
+mkdir -p %{buildroot}%{_localstatedir}/db/alexandrie/crate-index
+mkdir -p %{buildroot}%{_localstatedir}/db/alexandrie/crate-storage
+
+%clean
+rm -rf %{buildroot}
+
+%pre
+/usr/bin/getent group alexandrie > /dev/null || /usr/sbin/groupadd -r alexandrie
+/usr/bin/getent passwd alexandrie > /dev/null || /usr/sbin/useradd -r -d /usr/bin/alexandrie -s /sbin/nologin -g alexandrie alexandrie
+
+%post
+[ ! -d "%{_localstatedir}/db/alexandrie/crate-index/.git" ] && echo "Creating crate-index git repository in %{_localstatedir}/db/alexandrie/crate-index. Please setup origin and configure the crate index in: %{_localstatedir}/db/alexandrie/crate-index/config.json" && git -C %{_localstatedir}/db/alexandrie/crate-index init && git -C %{_localstatedir}/db/alexandrie/crate-index add config.json && git commit -C %{_localstatedir}/db/alexandrie/crate-index -m 'Added `config.json`'
+%systemd_post alexandrie.service
+
+%preun
+%systemd_preun alexandrie.service
+
+%postun
+%systemd_postun_with_restart alexandrie.service
+
+%files
+%defattr(-,root,root,-)
+%{_bindir}/*
+%{_unitdir}/alexandrie.service
+%config(noreplace) %{_sysconfdir}/alexandrie.conf
+%{_datadir}/alexandrie/assets/*
+%{_datadir}/alexandrie/templates/*
+%{_datadir}/alexandrie/syntect/dumps/*
+%attr(-,alexandrie,alexandrie) %dir %{_localstatedir}/db/alexandrie
+%attr(-,alexandrie,alexandrie) %dir %{_localstatedir}/db/alexandrie/crate-index
+%config(noreplace) %attr(-,alexandrie,alexandrie) %{_localstatedir}/db/alexandrie/crate-index/config.json
+%attr(-,alexandrie,alexandrie) %dir %{_localstatedir}/db/alexandrie/crate-storage

--- a/crates/alexandrie/.rpm/alexandrie.toml
+++ b/crates/alexandrie/.rpm/alexandrie.toml
@@ -1,0 +1,44 @@
+[general]
+bind_address = "127.0.0.1:3000"
+
+[frontend]
+enabled = true
+title = "Alexandrie"
+description = "An alternative crate registry for Cargo, the Rust package manager."
+# favicon = ""
+links = [
+    { name = "Github repository", href = "https://github.com/Hirevo/alexandrie" },
+    { name = "User documentation", href = "https://hirevo.github.io/alexandrie" },
+]
+
+[frontend.sessions]
+cookie_name = "alexandrie.sid"
+secret = "YOU_REALLY_SHOULD_CHANGE_THIS_BEFORE_DEPLOYING"
+
+[frontend.assets]
+path = "/usr/share/alexandrie/assets"
+
+[frontend.templates]
+path = "/usr/share/alexandrie/templates"
+
+[database]
+# url = "mysql://root:root@127.0.0.1:3306/alexandrie"
+# url = "postgresql://root:root@127.0.0.1:5432/alexandrie"
+url = "/var/db/alexandrie/alexandrie.db"
+
+[index]
+type = "command-line"
+path = "/var/db/alexandrie/crate-index"
+
+[storage]
+type = "disk"
+path = "/var/db/alexandrie/crate-storage"
+
+[syntect.syntaxes]
+type = "dump"
+path = "/usr/share/alexandrie/syntect/dumps/syntaxes.dump"
+
+[syntect.themes]
+type = "dump"
+path = "/usr/share/alexandrie/syntect/dumps/themes.dump"
+theme_name = "frontier-contrast"

--- a/crates/alexandrie/.rpm/crate-index-config.json
+++ b/crates/alexandrie/.rpm/crate-index-config.json
@@ -1,0 +1,5 @@
+{
+    "dl": "http://localhost:3000/api/v1/crates/{crate}/{version}/download",
+    "api": "http://localhost:3000",
+    "allowed-registries": ["https://github.com/rust-lang/crates.io-index"]
+}

--- a/crates/alexandrie/Cargo.toml
+++ b/crates/alexandrie/Cargo.toml
@@ -90,3 +90,20 @@ s3 = ["alexandrie-storage/s3"]
 
 [build-dependencies]
 shadow-rs = "0.5.25"
+
+[package.metadata.rpm]
+package = "alexandrie"
+
+[package.metadata.rpm.cargo]
+buildflags = ["--release"]
+
+[package.metadata.rpm.targets]
+alexandrie = { path = "/usr/bin/alexandrie" }
+
+[package.metadata.rpm.files]
+"alexandrie.service" = { path = "/usr/lib/systemd/system/alexandrie.service" }
+"alexandrie.toml" = { path = "/etc/alexandrie.conf" }
+"crate-index-config.json" = { path = "/var/db/alexandrie/crate-index/config.json" }
+"../../../assets/" = { path = "/usr/share/alexandrie/assets/" }
+"../../../templates/" = { path = "/usr/share/alexandrie/templates/" }
+"../../../syntect/dumps/" = { path = "/usr/share/alexandrie/syntect/dumps/" }


### PR DESCRIPTION
I added configurations for https://crates.io/crates/cargo-rpm to create a rpm package.

Installation:

* user/group `alexandrie` is created if it doesn't yet exist
* binary is installed to `/usr/bin/alexandrie`
* readonly resources are installed to `/usr/share/alexandrie`
* configuration file is installed to `/etc/alexandrie.conf`
* a systemd service is installed which starts alexandrie with `/etc/alexandrie.conf`
* storage (with write permissions for user alexandrie) is set up with empty directories in `/var/db/alexandrie`
* if there's not yet a git repository in `/var/db/alexandrie/crate-index`, it is setup with the default `config.json` of the installation script