### PR TITLE
fix: remove unused dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -87,7 +87,6 @@ dependencies = [
  "diesel",
  "diesel_migrations",
  "flate2",
- "futures",
  "handlebars",
  "hex",
  "log",
@@ -132,10 +131,8 @@ version = "0.1.0"
 dependencies = [
  "ammonia",
  "pulldown-cmark",
- "semver 0.11.0",
  "serde",
  "syntect",
- "thiserror",
 ]
 
 [[package]]

--- a/crates/alexandrie-rendering/Cargo.toml
+++ b/crates/alexandrie-rendering/Cargo.toml
@@ -14,14 +14,8 @@ license = "MIT OR Apache-2.0"
 # codecov = { repository = "Hirevo/alexandrie"}
 
 [dependencies]
-# data types
-semver = { version = "0.11.0", features = ["serde"] }
-
 # file formats
 serde = { version = "1.0.125", features = ["derive"] }
-
-# error handling
-thiserror = "1.0.24"
 
 # README rendering
 syntect = "4.5.0"

--- a/crates/alexandrie/Cargo.toml
+++ b/crates/alexandrie/Cargo.toml
@@ -51,7 +51,6 @@ diesel_migrations = "1.4.0"
 
 # async primitives
 async-std = { version = "1.9.0", features = ["attributes", "tokio1"] }
-futures = "0.3.14"
 
 # error handling
 thiserror = "1.0.24"


### PR DESCRIPTION
I half expect that these are used with some combination of features, but `cargo +nightly udeps --all-targets` claims that they are fully unused, and I couldn't find any usage either.