### PR TITLE
fix: check for compatible versions only

### DIFF
--- a/crates/alexandrie-index/src/error.rs
+++ b/crates/alexandrie-index/src/error.rs
@@ -1,4 +1,3 @@
-use semver::Version;
 use thiserror::Error;
 
 /// The Error type for the registry.
@@ -29,15 +28,5 @@ pub enum IndexError {
     CrateNotFound {
         /// The requested crate's name.
         name: String,
-    },
-    /// The published crate version is lower than the current hosted version.
-    #[error("the published version is too low (hosted version is {hosted}, and thus {published} <= {hosted})")]
-    VersionTooLow {
-        /// The krate's name.
-        krate: String,
-        /// The available hosted version.
-        hosted: Version,
-        /// The proposed version to be published.
-        published: Version,
     },
 }

--- a/crates/alexandrie-index/src/tree.rs
+++ b/crates/alexandrie-index/src/tree.rs
@@ -68,24 +68,7 @@ impl Tree {
     pub fn add_record(&self, record: CrateVersion) -> Result<(), Error> {
         let path = self.compute_record_path(record.name.as_str());
 
-        if let Ok(file) = fs::File::open(&path) {
-            let reader = io::BufReader::new(file);
-            let records = reader
-                .lines()
-                .map(|line| Ok(json::from_str::<CrateVersion>(line?.as_str())?))
-                .collect::<Result<Vec<CrateVersion>, Error>>()?;
-            let latest = records
-                .into_iter()
-                .max_by(|k1, k2| k1.vers.cmp(&k2.vers))
-                .expect("at least one record should exist");
-            if record.vers <= latest.vers {
-                return Err(Error::from(IndexError::VersionTooLow {
-                    krate: record.name,
-                    hosted: latest.vers,
-                    published: record.vers,
-                }));
-            }
-        } else {
+        if !path.exists() {
             let parent = path.parent().unwrap();
             fs::create_dir_all(parent)?;
         }

--- a/crates/alexandrie/src/api/crates/publish.rs
+++ b/crates/alexandrie/src/api/crates/publish.rs
@@ -292,13 +292,14 @@ pub(crate) async fn put(mut req: Request<State>) -> tide::Result {
                 }));
             }
 
-            //? Is the attempted publication version higher than the latest version for that release?
-            let requirement = VersionReq::parse(&format!("^{}.0.0", crate_desc.vers.major))?;
-            let latest = state.index.match_record(krate.name.as_str(), requirement)?;
-            if crate_desc.vers <= latest.vers {
+            //? Is there a compatible, higher version available than the attempted publication version?
+            let requirement = VersionReq::parse(&format!("^{}", crate_desc.vers))?;
+            if let Ok(latest_compatible) =
+                state.index.match_record(krate.name.as_str(), requirement)
+            {
                 return Err(Error::from(AlexError::VersionTooLow {
                     krate: krate.name,
-                    hosted: latest.vers,
+                    hosted: latest_compatible.vers,
                     published: crate_desc.vers,
                 }));
             }


### PR DESCRIPTION
Instead of checking for ^{major}.0.0, we're checking for ^{version} now,
which should reflect the actually intended behavior. Aside of that, if
no matching version is found, we're accepting the publish, because
without that behavior you couldn't publish any incompatible updates
anymore.

Aside of that, the check was duplicated, it happened in both the API and
the index. This duplicate was removed, to make sure we don't have
conflicting checks here again in the future.

ref: #116, #119, #109