### PR TITLE
Fix index version requirement bug

### DIFF
--- a/crates/alexandrie-index/src/error.rs
+++ b/crates/alexandrie-index/src/error.rs
@@ -26,10 +26,7 @@ pub enum Error {
 pub enum IndexError {
     /// No file matching crate
     #[error("file matching crate named '{name}', {path}, not found")]
-    CrateFileNotFound{
-        name: String,
-        path: String,
-    },
+    CrateFileNotFound { name: String, path: String },
     /// The requested crate cannot be found.
     #[error("no crate named '{name}' with version {version} found")]
     CrateNotFound {

--- a/crates/alexandrie-index/src/error.rs
+++ b/crates/alexandrie-index/src/error.rs
@@ -24,11 +24,18 @@ pub enum Error {
 /// The Error type for Alexandrie's own errors.
 #[derive(Error, Debug)]
 pub enum IndexError {
+    /// No file matching crate
+    #[error("file matching crate named '{name}', {path}, not found")]
+    CrateFileNotFound{
+        name: String,
+        path: String,
+    },
     /// The requested crate cannot be found.
-    #[error("no crate named '{name}' found")]
+    #[error("no crate named '{name}' with version {version} found")]
     CrateNotFound {
         /// The requested crate's name.
         name: String,
+        version: String,
     },
     /// The published crate version is lower than the current hosted version.
     #[error("the published version is too low (hosted version is {hosted}, and thus {published} <= {hosted})")]

--- a/crates/alexandrie-index/src/index/cli.rs
+++ b/crates/alexandrie-index/src/index/cli.rs
@@ -39,7 +39,7 @@ impl Indexer for CommandLineIndex {
         self.repo.commit_and_push(msg)
     }
 
-    fn match_record(&self, name: &str, req: VersionReq) -> Result<CrateVersion, Error> {
+    fn match_record(&self, name: &str, req: VersionReq) -> Result<Option<CrateVersion>, Error> {
         self.tree.match_record(name, req)
     }
 

--- a/crates/alexandrie-index/src/index/git2.rs
+++ b/crates/alexandrie-index/src/index/git2.rs
@@ -113,6 +113,18 @@ impl Indexer for Git2Index {
         }
     }
 
+    fn all_records(&self, name: &str) -> Result<Vec<CrateVersion>, Error> {
+        self.tree.all_records(name)
+    }
+
+    fn latest_record(&self, name: &str) -> Result<CrateVersion, Error> {
+        self.tree.latest_record(name)
+    }
+
+    fn match_record(&self, name: &str, req: VersionReq) -> Result<Option<CrateVersion>, Error> {
+        self.tree.match_record(name, req)
+    }
+
     fn commit_and_push(&self, msg: &str) -> Result<(), Error> {
         let repo = self.repo.lock().unwrap();
         let oid = {
@@ -133,18 +145,6 @@ impl Indexer for Git2Index {
         remote.push::<&'static str>(&[], None)?;
 
         Ok(())
-    }
-
-    fn match_record(&self, name: &str, req: VersionReq) -> Result<CrateVersion, Error> {
-        self.tree.match_record(name, req)
-    }
-
-    fn all_records(&self, name: &str) -> Result<Vec<CrateVersion>, Error> {
-        self.tree.all_records(name)
-    }
-
-    fn latest_record(&self, name: &str) -> Result<CrateVersion, Error> {
-        self.tree.latest_record(name)
     }
 
     fn add_record(&self, record: CrateVersion) -> Result<(), Error> {

--- a/crates/alexandrie-index/src/lib.rs
+++ b/crates/alexandrie-index/src/lib.rs
@@ -39,7 +39,7 @@ pub trait Indexer {
     /// Retrieves the latest version record of a crate.
     fn latest_record(&self, name: &str) -> Result<CrateVersion, Error>;
     /// Retrieves the latest crate version record that matches the given name and version requirement.
-    fn match_record(&self, name: &str, req: VersionReq) -> Result<CrateVersion, Error>;
+    fn match_record(&self, name: &str, req: VersionReq) -> Result<Option<CrateVersion>, Error>;
     /// Commits and pushes changes upstream.
     fn commit_and_push(&self, msg: &str) -> Result<(), Error>;
     /// Adds a new crate record into the index.
@@ -75,14 +75,6 @@ impl Indexer for Index {
         }
     }
 
-    fn commit_and_push(&self, msg: &str) -> Result<(), Error> {
-        match self {
-            Index::CommandLine(idx) => idx.commit_and_push(msg),
-            #[cfg(feature = "git2")]
-            Index::Git2(idx) => idx.commit_and_push(msg),
-        }
-    }
-
     fn all_records(&self, name: &str) -> Result<Vec<CrateVersion>, Error> {
         match self {
             Index::CommandLine(idx) => idx.all_records(name),
@@ -99,11 +91,19 @@ impl Indexer for Index {
         }
     }
 
-    fn match_record(&self, name: &str, req: VersionReq) -> Result<CrateVersion, Error> {
+    fn match_record(&self, name: &str, req: VersionReq) -> Result<Option<CrateVersion>, Error> {
         match self {
             Index::CommandLine(idx) => idx.match_record(name, req),
             #[cfg(feature = "git2")]
             Index::Git2(idx) => idx.match_record(name, req),
+        }
+    }
+
+    fn commit_and_push(&self, msg: &str) -> Result<(), Error> {
+        match self {
+            Index::CommandLine(idx) => idx.commit_and_push(msg),
+            #[cfg(feature = "git2")]
+            Index::Git2(idx) => idx.commit_and_push(msg),
         }
     }
 

--- a/crates/alexandrie-index/src/tree.rs
+++ b/crates/alexandrie-index/src/tree.rs
@@ -102,8 +102,8 @@ impl Tree {
     }
 
     pub fn alter_record<F>(&self, name: &str, version: Version, func: F) -> Result<(), Error>
-        where
-            F: FnOnce(&mut CrateVersion),
+    where
+        F: FnOnce(&mut CrateVersion),
     {
         let path = self.compute_record_path(name);
         let file = fs::File::open(path.as_path()).map_err(|err| match err.kind() {

--- a/crates/alexandrie/src/api/crates/publish.rs
+++ b/crates/alexandrie/src/api/crates/publish.rs
@@ -284,7 +284,7 @@ pub(crate) async fn put(mut req: Request<State>) -> tide::Result {
                     .filter(crate_authors::crate_id.eq(&krate.id))
                     .filter(crate_authors::author_id.eq(&author.id)),
             ))
-                .get_result(conn)?;
+            .get_result(conn)?;
             if !owned {
                 return Err(Error::from(AlexError::CrateNotOwned {
                     author,
@@ -413,8 +413,8 @@ mod tests {
         requirement: &VersionReq,
         versions: I,
     ) -> Option<&'a Version>
-        where
-            I: IntoIterator<Item=&'a Version>,
+    where
+        I: IntoIterator<Item = &'a Version>,
     {
         versions
             .into_iter()
@@ -428,7 +428,6 @@ mod tests {
             .map(|version_string| Version::parse(version_string).unwrap())
             .collect()
     }
-
 
     #[test]
     fn major_zero_with_match() {

--- a/crates/alexandrie/src/main.rs
+++ b/crates/alexandrie/src/main.rs
@@ -189,6 +189,8 @@ fn api_routes(state: State) -> Server<State> {
     app.at("/crates/:name/:version/download")
         .get(api::crates::download::get);
 
+    log::debug!("Test debug");
+
     app
 }
 


### PR DESCRIPTION
I wasn't able to push packages if a previous version of that package did exist.
Now I've tried to redo the `match_record` function to return an option. It's None if there were no prior packages within that version range.
Version ranges are also handled explicitly for cases where major is 0.