### PR TITLE
Bumped MSRV for CI runs to 1.68

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 #
 
 ### First stage: build the application
-FROM rust:1.50-slim-buster as builder
+FROM rust:1.68-slim-buster as builder
 
 ARG DATABASE
 

--- a/e2e/images/runner/Dockerfile
+++ b/e2e/images/runner/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.50
+FROM rust:1.68
 
 # install a few system dependencies
 RUN apt update


### PR DESCRIPTION
This PR simply increases the Rust version that our CI uses from 1.50 to 1.68.

Rust 1.50 is quite old now (it is older than the 2021 edition) and caused dependencies to no longer compile during CI runs.
