### PR TITLE
Removed unnecessary duplicate `tokio` runtime

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -139,13 +139,12 @@ dependencies = [
 name = "alexandrie-storage"
 version = "0.1.0"
 dependencies = [
- "lazy_static",
+ "async-std",
  "rusoto_core",
  "rusoto_s3",
  "semver 0.11.0",
  "serde",
  "thiserror",
- "tokio",
 ]
 
 [[package]]

--- a/crates/alexandrie-storage/Cargo.toml
+++ b/crates/alexandrie-storage/Cargo.toml
@@ -15,7 +15,7 @@ license = "MIT OR Apache-2.0"
 
 [dependencies]
 # async runtime
-async-std = { version = "1.9.0", features = ["attributes", "tokio1"], optional = true }
+async-std = { version = "1.9.0", features = ["tokio1"], optional = true }
 
 # data types
 semver = { version = "0.11.0", features = ["serde"] }

--- a/crates/alexandrie-storage/Cargo.toml
+++ b/crates/alexandrie-storage/Cargo.toml
@@ -31,5 +31,5 @@ rusoto_core = { version = "0.46.0", optional = true }
 rusoto_s3 = { version = "0.46.0", optional = true }
 
 [features]
-default = ["s3"]
+default = []
 s3 = ["async-std", "rusoto_core", "rusoto_s3"]

--- a/crates/alexandrie-storage/Cargo.toml
+++ b/crates/alexandrie-storage/Cargo.toml
@@ -14,6 +14,9 @@ license = "MIT OR Apache-2.0"
 # codecov = { repository = "Hirevo/alexandrie"}
 
 [dependencies]
+# async runtime
+async-std = { version = "1.9.0", features = ["attributes", "tokio1"], optional = true }
+
 # data types
 semver = { version = "0.11.0", features = ["serde"] }
 
@@ -24,11 +27,9 @@ serde = { version = "1.0.125", features = ["derive"] }
 thiserror = "1.0.24"
 
 # S3 crate storage
-lazy_static = { version = "1.4.0", optional = true }
 rusoto_core = { version = "0.46.0", optional = true }
 rusoto_s3 = { version = "0.46.0", optional = true }
-tokio = { version = "1.16.1", optional = true }
 
 [features]
-default = []
-s3 = ["lazy_static", "rusoto_core", "rusoto_s3", "tokio/rt-multi-thread"]
+default = ["s3"]
+s3 = ["async-std", "rusoto_core", "rusoto_s3"]

--- a/crates/alexandrie-storage/src/config/s3.rs
+++ b/crates/alexandrie-storage/src/config/s3.rs
@@ -1,6 +1,7 @@
-use crate::s3::S3Storage;
 use rusoto_core::Region;
 use serde::{Deserialize, Serialize};
+
+use crate::s3::S3Storage;
 
 /// The configuration struct for the 's3' storage strategy.
 ///

--- a/crates/alexandrie-storage/src/lib.rs
+++ b/crates/alexandrie-storage/src/lib.rs
@@ -13,7 +13,7 @@ pub mod s3;
 use crate::disk::DiskStorage;
 use crate::error::Error;
 
-/// The crate storage strategy enum type.  
+/// The crate storage strategy enum type.
 ///
 /// It represents which storage strategy is currently used.
 #[derive(Debug, Clone)]
@@ -34,19 +34,9 @@ pub trait Store {
     fn get_crate(&self, name: &str, version: Version) -> Result<Vec<u8>, Error>;
     /// Reads a crate tarball from the store.
     fn read_crate(&self, name: &str, version: Version) -> Result<Box<dyn Read>, Error> {
-        struct Reader {
-            source: Vec<u8>,
-        }
-
-        impl Read for Reader {
-            fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
-                self.source.as_slice().read(buf)
-            }
-        }
-
-        Ok(Box::new(Reader {
-            source: self.get_crate(name, version)?,
-        }))
+        let contents = self.get_crate(name, version)?;
+        let reader = io::Cursor::new(contents);
+        Ok(Box::new(reader))
     }
     /// Save a new crate tarball into the store.
     fn store_crate(&self, name: &str, version: Version, data: Vec<u8>) -> Result<(), Error>;
@@ -55,19 +45,9 @@ pub trait Store {
     fn get_readme(&self, name: &str, version: Version) -> Result<String, Error>;
     /// Reads a rendered README from the store.
     fn read_readme(&self, name: &str, version: Version) -> Result<Box<dyn Read>, Error> {
-        struct Reader {
-            source: Vec<u8>,
-        }
-
-        impl Read for Reader {
-            fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
-                self.source.as_slice().read(buf)
-            }
-        }
-
-        Ok(Box::new(Reader {
-            source: self.get_readme(name, version)?.into_bytes(),
-        }))
+        let contents = self.get_readme(name, version)?.into_bytes();
+        let reader = io::Cursor::new(contents);
+        Ok(Box::new(reader))
     }
     /// Stores a new rendered README into the store.
     fn store_readme(&self, name: &str, version: Version, data: String) -> Result<(), Error>;


### PR DESCRIPTION
This PR removes the need for the `s3` storage strategy implementation (`S3Storage`) to manage its own instance of a `tokio` runtime in order to use `rusoto_s3` async functions in a synchronous context.  

Instead, we try to get the current thread's handle to the already running `async_std` executor (that the main `alexandrie` crate is already using), and use that to call `block_on` on the futures returned by `rusoto_s3`.  

This works because `async_std` has a feature (called `tokio1`) to enable compatibility with the `tokio` 1.0 runtime.  

So this change avoids having duplicate runtimes running in the same output binary.  
