### PR TITLE
Move to the 2021 edition

### DIFF
--- a/crates/alexandrie-index/Cargo.toml
+++ b/crates/alexandrie-index/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "alexandrie-index"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 authors = ["Nicolas Polomack <nicolas@polomack.eu>"]
 description = "The index management library for Alexandrie, an alternative crate registry."
 repository = "https://github.com/Hirevo/alexandrie"

--- a/crates/alexandrie-index/Cargo.toml
+++ b/crates/alexandrie-index/Cargo.toml
@@ -28,3 +28,4 @@ thiserror = "1.0.24"
 git2 = { version = "0.13.18", optional = true }
 
 [features]
+git2 = ["dep:git2"]

--- a/crates/alexandrie-rendering/Cargo.toml
+++ b/crates/alexandrie-rendering/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "alexandrie-rendering"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 authors = ["Nicolas Polomack <nicolas@polomack.eu>"]
 description = "The markdown rendering library for Alexandrie, an alternative crate registry."
 repository = "https://github.com/Hirevo/alexandrie"

--- a/crates/alexandrie-storage/Cargo.toml
+++ b/crates/alexandrie-storage/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "alexandrie-storage"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 authors = ["Nicolas Polomack <nicolas@polomack.eu>"]
 description = "The crate storage library for Alexandrie, an alternative crate registry."
 repository = "https://github.com/Hirevo/alexandrie"

--- a/crates/alexandrie-storage/Cargo.toml
+++ b/crates/alexandrie-storage/Cargo.toml
@@ -32,4 +32,4 @@ rusoto_s3 = { version = "0.46.0", optional = true }
 
 [features]
 default = []
-s3 = ["async-std", "rusoto_core", "rusoto_s3"]
+s3 = ["dep:async-std", "dep:rusoto_core", "dep:rusoto_s3"]

--- a/crates/alexandrie/Cargo.toml
+++ b/crates/alexandrie/Cargo.toml
@@ -91,14 +91,14 @@ postgres = ["diesel/postgres", "diesel_migrations/postgres"]
 git2 = ["alexandrie-index/git2"]
 s3 = ["alexandrie-storage/s3"]
 frontend = [
-    "handlebars",
-    "oauth2",
-    "once_cell",
-    "regex",
-    "reqwest",
-    "num-format",
-    "bigdecimal",
-    "time",
+    "dep:handlebars",
+    "dep:oauth2",
+    "dep:once_cell",
+    "dep:regex",
+    "dep:reqwest",
+    "dep:num-format",
+    "dep:bigdecimal",
+    "dep:time",
     "diesel/numeric",
 ]
 

--- a/crates/alexandrie/Cargo.toml
+++ b/crates/alexandrie/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "alexandrie"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 rust-version = "1.68.0"
 authors = ["Nicolas Polomack <nicolas@polomack.eu>"]
 description = "An alternative crate registry, implemented in Rust."

--- a/helpers/syntect-dump/Cargo.toml
+++ b/helpers/syntect-dump/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "syntect-dump"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 authors = ["Nicolas Polomack <nicolas@polomack.eu>"]
 description = "A simple helper to generate syntect's binary dumps for Alexandrie"
 repository = "https://github.com/Hirevo/alexandrie"

--- a/wasm-pbkdf2/Cargo.toml
+++ b/wasm-pbkdf2/Cargo.toml
@@ -3,7 +3,7 @@ name = "wasm-pbkdf2"
 description = "WASM packaging of PBKDF2 utilities"
 version = "0.1.0"
 authors = ["Nicolas Polomack <nicolas@polomack.eu>"]
-edition = "2018"
+edition = "2021"
 
 [lib]
 crate-type = ["cdylib"]


### PR DESCRIPTION
This PR moves all the crates in the project to the 2021 edition of Rust.  

This PR also changes the definition of crate features using the rather new `dep:` syntax to simplify things a bit.