### PR TITLE
Fixed legacy configuration in examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,8 +95,7 @@ You can also configure things like the address and port of the server:
 
 ```toml
 [general]
-addr = "127.0.0.1"
-port = 3000
+bind_address = "127.0.0.1:3000"  # The endpoint and port on which to serve the service.
 ```
 
 Then, you need to configure a crate index.  

--- a/docs/src/getting-started.md
+++ b/docs/src/getting-started.md
@@ -67,8 +67,7 @@ You can also configure things like the address and port of the server:
 
 ```toml
 [general]
-addr = "127.0.0.1"  # Endpoint on which to serve the service.
-port = 3000         # Port on which to serve the service.
+bind_address = "127.0.0.1:3000"  # The endpoint and port on which to serve the service.
 ```
 
 Then, you need to configure a crate index.  


### PR DESCRIPTION
This PR simply fixes the mention of the legacy `addr` and `port` configuration options in `[general]`, which have been replaced by `bind_address`.  
