### PR TITLE
Fixed missing `frontend.auth.origin` in example configuration

### DIFF
--- a/alexandrie.toml
+++ b/alexandrie.toml
@@ -21,6 +21,9 @@ path = "assets"
 [frontend.templates]
 path = "templates"
 
+[frontend.auth]
+origin = "http://localhost:3000"
+
 [frontend.auth.local]
 enabled = true
 allow_registration = true


### PR DESCRIPTION
This PR simply fixes the missing `origin` configuration option (in `[frontend.auth]`), which is mandatory for the server to run, making this an easy thing to be confused by when the server errors out using the default configuration file.  

**Closes #152.**