### PR TITLE
Fixed errors in `cargo owner` commands

### DIFF
--- a/crates/alexandrie/src/api/crates/owners.rs
+++ b/crates/alexandrie/src/api/crates/owners.rs
@@ -171,7 +171,7 @@ pub(crate) async fn put(mut req: Request<State>) -> tide::Result {
         };
 
         let data = json!({
-            "ok": "true",
+            "ok": true,
             "msg": format!("{0} has been added as authors of {1}", authors_list, name),
         });
         Ok(utils::response::json(&data))
@@ -274,7 +274,7 @@ pub(crate) async fn delete(mut req: Request<State>) -> tide::Result {
         };
 
         let data = json!({
-            "ok": "true",
+            "ok": true,
             "msg": format!("{0} has been removed from authors of {1}", authors_list, name),
         });
         Ok(utils::response::json(&data))

--- a/docs/src/programmatic-api/crates/owners/delete.md
+++ b/docs/src/programmatic-api/crates/owners/delete.md
@@ -43,7 +43,7 @@ Currently, the registry will return an object of the following shape:
 ```js
 {
     // Whether the operation went well.
-    "ok": "true",
+    "ok": true,
     // A human-displayable message describing the operation's outcome.
     "msg": "John Doe and Nicolas Polomack has been removed from authors",
 }

--- a/docs/src/programmatic-api/crates/owners/put.md
+++ b/docs/src/programmatic-api/crates/owners/put.md
@@ -43,7 +43,7 @@ Currently, the registry will return an object of the following shape:
 ```js
 {
     // Whether the operation went well.
-    "ok": "true",
+    "ok": true,
     // A human-displayable message describing the operation's outcome.
     "msg": "John Doe and Nicolas Polomack has been added as authors",
 }

--- a/docs/src/programmatic-api/crates/unyank/put.md
+++ b/docs/src/programmatic-api/crates/unyank/put.md
@@ -29,6 +29,6 @@ Currently, the registry will return an object of the following shape:
 ```js
 {
     // Whether the operation went well.
-    "ok": "true",
+    "ok": true,
 }
 ```

--- a/docs/src/programmatic-api/crates/yank/delete.md
+++ b/docs/src/programmatic-api/crates/yank/delete.md
@@ -29,6 +29,6 @@ Currently, the registry will return an object of the following shape:
 ```js
 {
     // Whether the operation went well.
-    "ok": "true",
+    "ok": true,
 }
 ```


### PR DESCRIPTION
This PR addresses errors when running `cargo owner` commands.  

These errors were due to Alexandrie wrong response payload for those requests and `cargo` being unable to parse them.  
This meant that, while an error was observed, the operation of adding or removing an owner actually went completely fine.  

**Closes #156.**