### PR TITLE
Support for the `sparse-index` RFC

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,9 @@ crates/*/target
 # file for saving processes from `persist`
 /persist-dump.json
 
+# miscellaneous ignored folder
+/ignored
+
 # alexandrie local testing folders
 /app-data
 /crate-index

--- a/crates/alexandrie-index/src/index/cli.rs
+++ b/crates/alexandrie-index/src/index/cli.rs
@@ -5,7 +5,7 @@ use semver::{Version, VersionReq};
 
 use crate::error::Error;
 use crate::tree::Tree;
-use crate::{CrateVersion, Indexer};
+use crate::{ConfigFile, CrateVersion, Indexer};
 
 /// The 'command-line' crate index management strategy type.
 ///
@@ -37,6 +37,10 @@ impl Indexer for CommandLineIndex {
 
     fn commit_and_push(&self, msg: &str) -> Result<(), Error> {
         self.repo.commit_and_push(msg)
+    }
+
+    fn configuration(&self) -> Result<ConfigFile, Error> {
+        self.tree.configuration()
     }
 
     fn match_record(&self, name: &str, req: VersionReq) -> Result<CrateVersion, Error> {

--- a/crates/alexandrie-index/src/index/git2.rs
+++ b/crates/alexandrie-index/src/index/git2.rs
@@ -135,6 +135,10 @@ impl Indexer for Git2Index {
         Ok(())
     }
 
+    fn configuration(&self) -> Result<ConfigFile, Error> {
+        self.tree.configuration()
+    }
+
     fn match_record(&self, name: &str, req: VersionReq) -> Result<CrateVersion, Error> {
         self.tree.match_record(name, req)
     }

--- a/crates/alexandrie-index/src/index/git2.rs
+++ b/crates/alexandrie-index/src/index/git2.rs
@@ -5,7 +5,7 @@ use semver::{Version, VersionReq};
 
 use crate::error::Error;
 use crate::tree::Tree;
-use crate::{CrateVersion, Indexer};
+use crate::{ConfigFile, CrateVersion, Indexer};
 
 /// The 'git2' crate index management strategy type.
 ///

--- a/crates/alexandrie/src/api/mod.rs
+++ b/crates/alexandrie/src/api/mod.rs
@@ -4,3 +4,5 @@ pub mod account;
 pub mod categories;
 /// Crate-related endpoints (eg. "/api/v1/crates/*").
 pub mod crates;
+/// Sparse index endpoints (eg. "/api/v1/sparse/se/rd/serde").
+pub mod sparse;

--- a/crates/alexandrie/src/api/sparse/mod.rs
+++ b/crates/alexandrie/src/api/sparse/mod.rs
@@ -1,0 +1,62 @@
+use std::sync::Arc;
+
+use axum::extract::{Path, State};
+use axum::Json;
+use serde::{Deserialize, Serialize};
+
+use alexandrie_index::{ConfigFile, Indexer};
+
+use crate::config::AppState;
+use crate::error::ApiError;
+
+/// Response body for this route.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PathParams {
+    /// The crate's name.
+    pub fst: String,
+    /// The crate's description.
+    pub snd: String,
+    /// The crate's repository link.
+    #[serde(rename = "crate")]
+    pub krate: Option<String>,
+}
+
+/// Route to sparsly access index entries for a crate.
+pub async fn get(
+    State(state): State<Arc<AppState>>,
+    Path(params): Path<PathParams>,
+) -> Result<String, ApiError> {
+    let (fst, snd, krate) = match params.krate.as_deref() {
+        Some(krate) => (params.fst.as_str(), Some(params.snd.as_str()), krate),
+        None => (params.fst.as_str(), None, params.snd.as_str()),
+    };
+
+    let maybe_expected = match krate.len() {
+        0 => None,
+        1 => Some(("1", None)),
+        2 => Some(("2", None)),
+        3 => Some(("3", Some(&krate[..1]))),
+        _ => Some((&krate[..2], Some(&krate[2..4]))),
+    };
+
+    if maybe_expected.map_or(true, |it| it != (fst, snd)) {
+        return Err(ApiError::msg("the crate could not be found"));
+    }
+
+    let records = state.index.all_records(krate)?;
+
+    let mut output = String::default();
+    for record in records {
+        let record = json::to_string(&record)?;
+        output.push_str(&record);
+        output.push('\n');
+    }
+
+    Ok(output)
+}
+
+/// Route to sparsly access the index's configuration.
+pub async fn get_config(State(state): State<Arc<AppState>>) -> Result<Json<ConfigFile>, ApiError> {
+    let config = state.index.configuration()?;
+    Ok(Json(config))
+}

--- a/crates/alexandrie/src/main.rs
+++ b/crates/alexandrie/src/main.rs
@@ -31,6 +31,8 @@ use clap::Parser;
 use diesel_migrations::MigrationHarness;
 use tower_http::trace::{self, TraceLayer};
 use tracing::Level;
+use tracing_subscriber::filter::LevelFilter;
+use tracing_subscriber::EnvFilter;
 
 #[cfg(feature = "frontend")]
 use axum::http::StatusCode;
@@ -40,8 +42,6 @@ use tower_http::services::ServeDir;
 use tower_sessions::cookie::SameSite;
 #[cfg(feature = "frontend")]
 use tower_sessions::SessionManagerLayer;
-use tracing_subscriber::filter::LevelFilter;
-use tracing_subscriber::EnvFilter;
 
 /// API endpoints definitions.
 pub mod api;
@@ -185,6 +185,9 @@ fn api_routes() -> Router<Arc<AppState>> {
             "/crates/:name/:version/download",
             get(api::crates::download::get),
         )
+        .route("/sparse/:fst/:snd/:crate", get(api::sparse::get))
+        .route("/sparse/:fst/:snd", get(api::sparse::get))
+        .route("/sparse/config.json", get(api::sparse::get_config))
 }
 
 #[derive(Debug, Parser)]


### PR DESCRIPTION
This PR implements [Cargo's new `sparse-index` RFC (RFC #2789)], which has become stable since [Rust 1.68 (March 9th, 2023)].  

[Cargo's new `sparse-index` RFC (RFC #2789)]: https://github.com/rust-lang/rfcs/blob/master/text/2789-sparse-index.md
[Rust 1.68 (March 9th, 2023)]: https://blog.rust-lang.org/2023/03/09/Rust-1.68.0.html#cargos-sparse-protocol

Cargo plans to make the use of this new protocol be the default for `crates.io` in Rust 1.70 (June 1st, 2023).  
Because of this, I predict users to start to expect every registry to behave that way quite soon, if it isn't already the case.  

This protocol makes working with registries with a very large crate index way snappier for users, because `cargo` can selectively request the metadata for the crates it is specifically interested in for the current operation it is doing, instead of having to bring its local cloned copy of the index up-to-date using `git`, which can take a significant amount of time for a large crate index, or when the local clone hasn't been updated for a while and the crate index has been very active.

The routes for the sparse index API are all under the `/api/v1/sparse/` base path.  

The `Indexer` trait has been extended a bit, notably to allow retrieving the crate configuration file.  

### Task-list before merging

- [ ] Implementation
  - [x] Basic support
  - [ ] `Etag` and `If-None-Match` support
  - [ ] `Last-Modified` and `If-Modified-Since` support
  - [ ] `canonical` field in index configuration file ([rust-lang/cargo#10964](https://github.com/rust-lang/cargo/issues/10964))
- [ ] Documentation
  - [ ] Registry configuration
  - [ ] Cargo (user-side) configuration