### PR TITLE
Disallow anonymous crate browsing in the frontend

### DIFF
--- a/alexandrie.toml
+++ b/alexandrie.toml
@@ -11,6 +11,7 @@ links = [
     { name = "Github repository", href = "https://github.com/Hirevo/alexandrie" },
     { name = "User documentation", href = "https://hirevo.github.io/alexandrie" },
 ]
+login_required = false
 
 [frontend.sessions]
 cookie_name = "alexandrie.sid"

--- a/crates/alexandrie/src/config/frontend/mod.rs
+++ b/crates/alexandrie/src/config/frontend/mod.rs
@@ -60,6 +60,8 @@ pub struct FrontendConfig {
     pub favicon: Option<String>,
     /// Some related links.
     pub links: Option<Vec<Link>>,
+    /// Whether to disallow anonymous browsing of the registry.
+    pub login_required: bool,
     /// Assets configuration options.
     pub assets: AssetsConfig,
     /// Templates configuration options.

--- a/crates/alexandrie/src/config/mod.rs
+++ b/crates/alexandrie/src/config/mod.rs
@@ -94,3 +94,11 @@ impl From<Config> for State {
         }
     }
 }
+
+impl State {
+    /// Returns whether we require users to log in to browse crates.
+    #[cfg(feature = "frontend")]
+    pub fn is_login_required(&self) -> bool {
+        self.frontend.config.login_required
+    }
+}

--- a/crates/alexandrie/src/frontend/index.rs
+++ b/crates/alexandrie/src/frontend/index.rs
@@ -13,6 +13,10 @@ use crate::State;
 
 pub(crate) async fn get(req: Request<State>) -> tide::Result {
     let user = req.get_author();
+    if req.state().is_login_required() && user.is_none() {
+        return Ok(utils::response::redirect("/account/login"));
+    }
+
     let state = req.state().clone();
     let db = &state.db;
 

--- a/crates/alexandrie/src/frontend/krate.rs
+++ b/crates/alexandrie/src/frontend/krate.rs
@@ -27,6 +27,10 @@ pub(crate) async fn get(req: Request<State>) -> tide::Result {
     let canon_name = utils::canonical_name(name);
 
     let user = req.get_author();
+    if req.state().is_login_required() && user.is_none() {
+        return Ok(utils::response::redirect("/account/login"));
+    }
+
     let state = req.state().clone();
     let db = &state.db;
 

--- a/crates/alexandrie/src/frontend/last_updated.rs
+++ b/crates/alexandrie/src/frontend/last_updated.rs
@@ -27,6 +27,10 @@ pub(crate) async fn get(req: Request<State>) -> tide::Result {
     let page_number = params.page.map_or_else(|| 1, |page| page.get());
 
     let user = req.get_author();
+    if req.state().is_login_required() && user.is_none() {
+        return Ok(utils::response::redirect("/account/login"));
+    }
+
     let state = req.state().clone();
     let db = &state.db;
 

--- a/crates/alexandrie/src/frontend/most_downloaded.rs
+++ b/crates/alexandrie/src/frontend/most_downloaded.rs
@@ -27,6 +27,10 @@ pub(crate) async fn get(req: Request<State>) -> tide::Result {
     let page_number = params.page.map_or_else(|| 1, |page| page.get());
 
     let user = req.get_author();
+    if req.state().is_login_required() && user.is_none() {
+        return Ok(utils::response::redirect("/account/login"));
+    }
+
     let state = req.state().clone();
     let db = &state.db;
 

--- a/crates/alexandrie/src/frontend/search.rs
+++ b/crates/alexandrie/src/frontend/search.rs
@@ -34,6 +34,10 @@ pub(crate) async fn get(req: Request<State>) -> tide::Result {
     let page_number = params.page.map_or_else(|| 1, |page| page.get());
 
     let user = req.get_author();
+    if req.state().is_login_required() && user.is_none() {
+        return Ok(utils::response::redirect("/account/login"));
+    }
+
     let state = req.state().clone();
     let db = &state.db;
 

--- a/docker/mysql/alexandrie.toml
+++ b/docker/mysql/alexandrie.toml
@@ -13,6 +13,7 @@ max_crate_size = "50 MB"
 enabled = true
 title = "Alexandrie"
 description = "An alternative crate registry for Cargo, the Rust package manager."
+login_required = false
 
 [frontend.sessions]
 cookie_name = "alexandrie.sid"

--- a/docker/postgres/alexandrie.toml
+++ b/docker/postgres/alexandrie.toml
@@ -13,6 +13,7 @@ max_crate_size = "50 MB"
 enabled = true
 title = "Alexandrie"
 description = "An alternative crate registry for Cargo, the Rust package manager."
+login_required = false
 
 [frontend.sessions]
 cookie_name = "alexandrie.sid"

--- a/docker/sqlite/alexandrie.toml
+++ b/docker/sqlite/alexandrie.toml
@@ -13,6 +13,7 @@ max_crate_size = "50 MB"
 enabled = true
 title = "Alexandrie"
 description = "An alternative crate registry for Cargo, the Rust package manager."
+login_required = false
 
 [frontend.sessions]
 cookie_name = "alexandrie.sid"


### PR DESCRIPTION
Many users expressed the interest in restricting the anonymous browsing of the registry's crates, in the effort of allowing a truly private (in the privacy sense) crate registry.  

This PR adds a new boolean configuration option called `login_required`, which, if enabled, prevents unauthenticated users from browsing the registry using the frontend's pages.  

This, however, still does not make the registry completely opaque to anonymous users by itself, due to some of Cargo's APIs not supporting authentication as of yet.  

Cargo sends no token to these endpoints so we can't really require one, like:
- the crate search endpoint (`/api/v1/crates?<q>`), used by `cargo search`, which can be used to list all crates in the registry.  
- or the crate download endpoint (`/api/v1/crates/:crate/:version/download`), used by `cargo fetch`, which can be used to download any crate in the registry.  

(I talk about this situation in more depth in [this issue comment](https://github.com/Hirevo/alexandrie/issues/152#issuecomment-1557949559), if you wonder why is it like that and what is currently planned to be done about it by the Cargo team)

So, as of today, the definitive way of preventing every kind of anonymous browsing would still be to host the registry in a private network, and require the use of VPN or a proxy (like an SSH tunnel) to access it.  