### PR TITLE
Move to `tower-sessions`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -48,7 +48,6 @@ dependencies = [
  "async-session",
  "axum",
  "axum-extra",
- "axum-sessions",
  "bigdecimal",
  "built",
  "byteorder",
@@ -80,6 +79,7 @@ dependencies = [
  "toml 0.7.5",
  "tower",
  "tower-http",
+ "tower-sessions",
  "tracing",
  "tracing-subscriber",
  "url",
@@ -247,7 +247,7 @@ dependencies = [
  "bincode",
  "blake3",
  "chrono",
- "hmac 0.11.0",
+ "hmac",
  "log",
  "rand",
  "serde",
@@ -263,7 +263,7 @@ checksum = "b9ccdd8f2a161be9bd5c023df56f1b2a0bd1d83872ae53b71a84a12c9bf6e842"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.22",
+ "syn 2.0.32",
 ]
 
 [[package]]
@@ -331,7 +331,6 @@ dependencies = [
  "axum",
  "axum-core",
  "bytes",
- "cookie",
  "futures-util",
  "http",
  "http-body",
@@ -343,22 +342,6 @@ dependencies = [
  "tower-http",
  "tower-layer",
  "tower-service",
-]
-
-[[package]]
-name = "axum-sessions"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "714cad544cd87d8da821cda715bb9aaa5d4d1adbdb64c549b18138e3cbf93c44"
-dependencies = [
- "async-session",
- "axum",
- "axum-extra",
- "futures",
- "http-body",
- "tokio",
- "tower",
- "tracing",
 ]
 
 [[package]]
@@ -579,7 +562,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.22",
+ "syn 2.0.32",
 ]
 
 [[package]]
@@ -615,12 +598,7 @@ version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7efb37c3e1ccb1ff97164ad95ac1606e8ccd35b3fa0a7d99a304c7f4a428cc24"
 dependencies = [
- "base64 0.21.2",
- "hmac 0.12.1",
  "percent-encoding",
- "rand",
- "sha2 0.10.7",
- "subtle",
  "time 0.3.22",
  "version_check",
 ]
@@ -837,7 +815,7 @@ dependencies = [
  "diesel_table_macro_syntax",
  "proc-macro2",
  "quote",
- "syn 2.0.22",
+ "syn 2.0.32",
 ]
 
 [[package]]
@@ -857,7 +835,7 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc5557efc453706fed5e4fa85006fe9817c224c3f480a34c7e5959fd700921c5"
 dependencies = [
- "syn 2.0.22",
+ "syn 2.0.32",
 ]
 
 [[package]]
@@ -877,7 +855,6 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer 0.10.4",
  "crypto-common",
- "subtle",
 ]
 
 [[package]]
@@ -1115,7 +1092,7 @@ checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.22",
+ "syn 2.0.32",
 ]
 
 [[package]]
@@ -1329,15 +1306,6 @@ checksum = "2a2a2320eb7ec0ebe8da8f744d7812d9fc4cb4d09344ac01898dbcb6a20ae69b"
 dependencies = [
  "crypto-mac 0.11.1",
  "digest 0.9.0",
-]
-
-[[package]]
-name = "hmac"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
-dependencies = [
- "digest 0.10.7",
 ]
 
 [[package]]
@@ -1680,6 +1648,7 @@ checksum = "c1cc9717a20b1bb222f333e6a92fd32f7d8a18ddc5a3191a11af45dcbf4dcd16"
 dependencies = [
  "autocfg",
  "scopeguard",
+ "serde",
 ]
 
 [[package]]
@@ -2055,7 +2024,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.22",
+ "syn 2.0.32",
 ]
 
 [[package]]
@@ -2150,7 +2119,7 @@ dependencies = [
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.22",
+ "syn 2.0.32",
 ]
 
 [[package]]
@@ -2219,7 +2188,7 @@ checksum = "39407670928234ebc5e6e580247dd567ad73a3578460c5990f9503df207e8f07"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.22",
+ "syn 2.0.32",
 ]
 
 [[package]]
@@ -2307,9 +2276,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.28"
+version = "1.0.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b9ab9c7eadfd8df19006f1cf1a4aed13540ed5cbc047010ece5826e10825488"
+checksum = "5907a1b7c277254a8b15170f6e7c97cfa60ee7872a3217663bb81151e48184bb"
 dependencies = [
  "proc-macro2",
 ]
@@ -2563,7 +2532,7 @@ dependencies = [
  "digest 0.9.0",
  "futures",
  "hex",
- "hmac 0.11.0",
+ "hmac",
  "http",
  "hyper",
  "log",
@@ -2754,29 +2723,29 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.164"
+version = "1.0.188"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e8c8cf938e98f769bc164923b06dce91cea1751522f46f8466461af04c9027d"
+checksum = "cf9e0fcba69a370eed61bcf2b728575f726b50b55cba78064753d708ddc7549e"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.164"
+version = "1.0.188"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9735b638ccc51c28bf6914d90a2e9725b377144fc612c49a611fddd1b631d68"
+checksum = "4eca7ac642d82aa35b60049a6eccb4be6be75e599bd2e9adb5f875a737654af2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.22",
+ "syn 2.0.32",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.99"
+version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46266871c240a00b8f503b877622fe33430b3c7d963bdc0f2adc511e54a1eae3"
+checksum = "6b420ce6e3d8bd882e9b243c6eed35dbc9a6110c9769e74b584e0d68d1f20c65"
 dependencies = [
  "itoa",
  "ryu",
@@ -2985,9 +2954,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.22"
+version = "2.0.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2efbeae7acf4eabd6bcdcbd11c92f45231ddda7539edc7806bd1a04a03b24616"
+checksum = "239814284fd6f1a4ffe4ca893952cdd93c224b6a1571c9a9eadd670295c0c9e2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3225,22 +3194,22 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.40"
+version = "1.0.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "978c9a314bd8dc99be594bc3c175faaa9794be04a5a5e153caba6915336cebac"
+checksum = "9d6d7a740b8a666a7e828dd00da9c0dc290dff53154ea77ac109281de90589b7"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.40"
+version = "1.0.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
+checksum = "49922ecae66cc8a249b77e68d1d0623c1b2c514f0060c27cdc68bd62a1219d35"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.22",
+ "syn 2.0.32",
 ]
 
 [[package]]
@@ -3332,7 +3301,7 @@ checksum = "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.22",
+ "syn 2.0.32",
 ]
 
 [[package]]
@@ -3429,6 +3398,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "tower-cookies"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40f38d941a2ffd8402b36e02ae407637a9caceb693aaf2edc910437db0f36984"
+dependencies = [
+ "async-trait",
+ "axum-core",
+ "cookie",
+ "futures-util",
+ "http",
+ "parking_lot",
+ "pin-project-lite",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
 name = "tower-http"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3466,6 +3452,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52"
 
 [[package]]
+name = "tower-sessions"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0cca8ce4e897a525607a29522f0ab64cdcef5c38ed30d6084623288ff989b42"
+dependencies = [
+ "async-trait",
+ "axum-core",
+ "http",
+ "parking_lot",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "time 0.3.22",
+ "tower-cookies",
+ "tower-layer",
+ "tower-service",
+ "uuid",
+]
+
+[[package]]
 name = "tracing"
 version = "0.1.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3486,7 +3492,7 @@ checksum = "5f4f31f56159e98206da9efd823404b79b6ef3143b4a7ab76e67b1751b25a4ab"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.22",
+ "syn 2.0.32",
 ]
 
 [[package]]
@@ -3620,9 +3626,9 @@ checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 
 [[package]]
 name = "uuid"
-version = "1.4.0"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d023da39d1fde5a8a3fe1f3e01ca9632ada0a63e9797de55a879d6e2236277be"
+checksum = "79daa5ed5740825c40b389c5e50312b9c86df53fccd33f281df655642b43869d"
 dependencies = [
  "getrandom",
  "serde",
@@ -3698,7 +3704,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.22",
+ "syn 2.0.32",
  "wasm-bindgen-shared",
 ]
 
@@ -3732,7 +3738,7 @@ checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.22",
+ "syn 2.0.32",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -73,7 +73,7 @@ dependencies = [
  "tantivy-analysis-contrib",
  "tar",
  "thiserror",
- "time 0.3.22",
+ "time 0.3.29",
  "tokio",
  "toml 0.7.5",
  "tower",
@@ -214,9 +214,9 @@ checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
 
 [[package]]
 name = "async-trait"
-version = "0.1.68"
+version = "0.1.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9ccdd8f2a161be9bd5c023df56f1b2a0bd1d83872ae53b71a84a12c9bf6e842"
+checksum = "bc00ceb34980c03614e35a3a4e218276a0a824e911d07651cd0d858a51e8c0f0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -529,7 +529,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7efb37c3e1ccb1ff97164ad95ac1606e8ccd35b3fa0a7d99a304c7f4a428cc24"
 dependencies = [
  "percent-encoding",
- "time 0.3.22",
+ "time 0.3.29",
  "version_check",
 ]
 
@@ -672,6 +672,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "deranged"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2696e8a945f658fd14dc3b87242e6b80cd0f36ff04ea560fa39082368847946"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "derive_builder"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -722,7 +731,7 @@ dependencies = [
  "percent-encoding",
  "pq-sys",
  "r2d2",
- "time 0.3.22",
+ "time 0.3.29",
  "url",
 ]
 
@@ -2134,7 +2143,7 @@ dependencies = [
  "line-wrap",
  "quick-xml",
  "serde",
- "time 0.3.22",
+ "time 0.3.29",
 ]
 
 [[package]]
@@ -2961,7 +2970,7 @@ dependencies = [
  "tantivy-tokenizer-api",
  "tempfile",
  "thiserror",
- "time 0.3.22",
+ "time 0.3.29",
  "uuid",
  "winapi",
 ]
@@ -3015,7 +3024,7 @@ dependencies = [
  "byteorder",
  "ownedbytes",
  "serde",
- "time 0.3.22",
+ "time 0.3.29",
 ]
 
 [[package]]
@@ -3108,18 +3117,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.48"
+version = "1.0.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d6d7a740b8a666a7e828dd00da9c0dc290dff53154ea77ac109281de90589b7"
+checksum = "1177e8c6d7ede7afde3585fd2513e611227efd6481bd78d2e82ba1ce16557ed4"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.48"
+version = "1.0.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49922ecae66cc8a249b77e68d1d0623c1b2c514f0060c27cdc68bd62a1219d35"
+checksum = "10712f02019e9288794769fba95cd6847df9874d49d871d062172f9dd41bc4cc"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3149,10 +3158,11 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.22"
+version = "0.3.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea9e1b3cf1243ae005d9e74085d4d542f3125458f3a81af210d901dcd7411efd"
+checksum = "426f806f4089c493dcac0d24c29c01e2c38baf8e30f1b716ee37e83d200b18fe"
 dependencies = [
+ "deranged",
  "itoa",
  "serde",
  "time-core",
@@ -3161,15 +3171,15 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7300fbefb4dadc1af235a9cef3737cea692a9d97e1b9cbcd4ebdae6f8868e6fb"
+checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
 
 [[package]]
 name = "time-macros"
-version = "0.2.9"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "372950940a5f07bf38dbe211d7283c9e6d7327df53794992d293e534c733d09b"
+checksum = "4ad70d68dba9e1f8aceda7aa6711965dfec1cac869f311a51bd08b3a2ccbce20"
 dependencies = [
  "time-core",
 ]
@@ -3367,9 +3377,9 @@ checksum = "b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52"
 
 [[package]]
 name = "tower-sessions"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92fb80fab7ba43e547ef5e051426537d5ada0aacb6fd17132430a34e7ca2164e"
+checksum = "5b51233895d1173cae657a2ce44bd414efe20ae0971216f8ddf6ca528498a20c"
 dependencies = [
  "async-trait",
  "axum-core",
@@ -3378,7 +3388,7 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror",
- "time 0.3.22",
+ "time 0.3.29",
  "tower-cookies",
  "tower-layer",
  "tower-service",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -23,7 +23,7 @@ version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c99f64d1e06488f620f932677e24bc6e2897582980441ae90a671415bd7ec2f"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "once_cell",
  "version_check",
 ]
@@ -45,7 +45,6 @@ dependencies = [
  "alexandrie-rendering",
  "alexandrie-storage",
  "anyhow",
- "async-session",
  "axum",
  "axum-extra",
  "bigdecimal",
@@ -208,52 +207,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bddcadddf5e9015d310179a59bb28c4d4b9920ad0f11e8e14dbadf654890c9a6"
 
 [[package]]
-name = "arrayref"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b4930d2cb77ce62f89ee5d5289b4ac049559b1c45539271f5ed4fdc7db34545"
-
-[[package]]
-name = "arrayvec"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
-
-[[package]]
 name = "arrayvec"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
-
-[[package]]
-name = "async-lock"
-version = "2.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa24f727524730b077666307f2734b4a1a1c57acb79193127dcc8914d5242dd7"
-dependencies = [
- "event-listener",
-]
-
-[[package]]
-name = "async-session"
-version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07da4ce523b4e2ebaaf330746761df23a465b951a83d84bbce4233dabedae630"
-dependencies = [
- "anyhow",
- "async-lock",
- "async-trait",
- "base64 0.13.1",
- "bincode",
- "blake3",
- "chrono",
- "hmac",
- "log",
- "rand",
- "serde",
- "serde_json",
- "sha2 0.9.9",
-]
 
 [[package]]
 name = "async-trait"
@@ -352,7 +309,7 @@ checksum = "4319208da049c43661739c5fade2ba182f09d1dc2299b32298d3a31692b17e12"
 dependencies = [
  "addr2line",
  "cc",
- "cfg-if 1.0.0",
+ "cfg-if",
  "libc",
  "miniz_oxide",
  "object",
@@ -411,21 +368,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8c7d2ac73c167c06af4a5f37e6e59d84148d57ccbe4480b76f0273eefea82d7"
 dependencies = [
  "crunchy",
-]
-
-[[package]]
-name = "blake3"
-version = "0.3.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b64485778c4f16a6a5a9d335e80d449ac6c70cdd6a06d2af18a6f6f775a125b3"
-dependencies = [
- "arrayref",
- "arrayvec 0.5.2",
- "cc",
- "cfg-if 0.1.10",
- "constant_time_eq",
- "crypto-mac 0.8.0",
- "digest 0.9.0",
 ]
 
 [[package]]
@@ -501,12 +443,6 @@ name = "census"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fafee10a5dd1cffcb5cc560e0d0df8803d7355a2b12272e3557dee57314cb6e"
-
-[[package]]
-name = "cfg-if"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 
 [[package]]
 name = "cfg-if"
@@ -587,12 +523,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "constant_time_eq"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
-
-[[package]]
 name = "cookie"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -634,7 +564,7 @@ version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
 ]
 
 [[package]]
@@ -643,7 +573,7 @@ version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a33c2bf77f2df06183c3aa30d1e96c0695a313d4f9c453cc3762a6db39f99200"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "crossbeam-utils",
 ]
 
@@ -653,7 +583,7 @@ version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce6fd6f855243022dcecf8702fef0c297d4338e226845fe067f6341ad9fa0cef"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "crossbeam-epoch",
  "crossbeam-utils",
 ]
@@ -665,7 +595,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae211234986c545741a7dc064309f67ee1e5ad243d0e48335adc0484d960bcc7"
 dependencies = [
  "autocfg",
- "cfg-if 1.0.0",
+ "cfg-if",
  "crossbeam-utils",
  "memoffset",
  "scopeguard",
@@ -677,7 +607,7 @@ version = "0.8.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a22b2d63d4d1dc0b7f1b6b2747dd0088008a9be28b6ddf0b1e7d335e3037294"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
 ]
 
 [[package]]
@@ -694,16 +624,6 @@ checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
  "typenum",
-]
-
-[[package]]
-name = "crypto-mac"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b584a330336237c1eecd3e94266efb216c56ed91225d634cb2991c5f3fd1aeab"
-dependencies = [
- "generic-array",
- "subtle",
 ]
 
 [[package]]
@@ -863,7 +783,7 @@ version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "dirs-sys-next",
 ]
 
@@ -896,7 +816,7 @@ version = "0.8.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071a31f4ee85403370b58aca746f01041ede6f0da2730960ad001edc2b71b394"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
 ]
 
 [[package]]
@@ -925,12 +845,6 @@ dependencies = [
  "cc",
  "libc",
 ]
-
-[[package]]
-name = "event-listener"
-version = "2.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
 
 [[package]]
 name = "fail"
@@ -964,7 +878,7 @@ version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5cbc844cecaee9d4443931972e1289c8ff485cb4cc2767cb03ca139ed6885153"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "libc",
  "redox_syscall 0.2.16",
  "windows-sys 0.48.0",
@@ -1163,7 +1077,7 @@ version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be4136b2a15dd319360be1c07d9933517ccf0be8f16bf62a3bee4f0d618df427"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "js-sys",
  "libc",
  "wasi 0.11.0+wasi-snapshot-preview1",
@@ -1304,7 +1218,7 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a2a2320eb7ec0ebe8da8f744d7812d9fc4cb4d09344ac01898dbcb6a20ae69b"
 dependencies = [
- "crypto-mac 0.11.1",
+ "crypto-mac",
  "digest 0.9.0",
 ]
 
@@ -1483,7 +1397,7 @@ version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "js-sys",
  "wasm-bindgen",
  "web-sys",
@@ -1663,7 +1577,7 @@ version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff50ecb28bb86013e935fb6683ab1f6d3a20016f123c76fd4c27470076ac30f5"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "generator",
  "pin-utils",
  "scoped-tls",
@@ -1896,7 +1810,7 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a652d9771a63711fd3c3deb670acfbe5c30a4072e664d7a3bf5a9e1056ac72c3"
 dependencies = [
- "arrayvec 0.7.4",
+ "arrayvec",
  "itoa",
 ]
 
@@ -2008,7 +1922,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "345df152bc43501c5eb9e4654ff05f794effb78d4efe3d53abc158baddc0703d"
 dependencies = [
  "bitflags 1.3.2",
- "cfg-if 1.0.0",
+ "cfg-if",
  "foreign-types",
  "libc",
  "once_cell",
@@ -2076,7 +1990,7 @@ version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93f00c865fe7cabf650081affecd3871070f26767e7b2070a3ffae14c654b447"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "libc",
  "redox_syscall 0.3.5",
  "smallvec",
@@ -2788,7 +2702,7 @@ version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f04293dc80c3993519f2d7f6f511707ee7094fe0c6d3406feb330cdb3540eba3"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "cpufeatures",
  "digest 0.10.7",
 ]
@@ -2800,7 +2714,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d58a1e1bf39749807d89cf2d98ac2dfa0ff1cb3faa38fbb64dd88ac8013d800"
 dependencies = [
  "block-buffer 0.9.0",
- "cfg-if 1.0.0",
+ "cfg-if",
  "cpufeatures",
  "digest 0.9.0",
  "opaque-debug",
@@ -2812,7 +2726,7 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479fb9d862239e610720565ca91403019f2f00410f1864c5aa7479b950a76ed8"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "cpufeatures",
  "digest 0.10.7",
 ]
@@ -3174,7 +3088,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "31c0432476357e58790aaa47a8efb0c5138f137343f3b5f23bd36a27e3b0a6d6"
 dependencies = [
  "autocfg",
- "cfg-if 1.0.0",
+ "cfg-if",
  "fastrand",
  "redox_syscall 0.3.5",
  "rustix",
@@ -3218,7 +3132,7 @@ version = "1.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fdd6f064ccff2d6567adcb3873ca630700f00b5ad3f060c25b5dcfd9a4ce152"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "once_cell",
 ]
 
@@ -3454,8 +3368,7 @@ checksum = "b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52"
 [[package]]
 name = "tower-sessions"
 version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0cca8ce4e897a525607a29522f0ab64cdcef5c38ed30d6084623288ff989b42"
+source = "git+https://github.com/maxcountryman/tower-sessions?branch=main#0885cc9e992832f6de71c322c33d06be9fc5f0c1"
 dependencies = [
  "async-trait",
  "axum-core",
@@ -3477,7 +3390,7 @@ version = "0.1.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ce8c33a8d48bd45d624a6e523445fd21ec13d3653cd51f681abf67418f54eb8"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "log",
  "pin-project-lite",
  "tracing-attributes",
@@ -3689,7 +3602,7 @@ version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7706a72ab36d8cb1f80ffbf0e071533974a60d0a308d01a5d0375bf60499a342"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "wasm-bindgen-macro",
 ]
 
@@ -3714,7 +3627,7 @@ version = "0.4.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c02dbc21516f9f1f04f187958890d7e6026df8d16540b7ad9492bc34a67cea03"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "js-sys",
  "wasm-bindgen",
  "web-sys",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3367,8 +3367,9 @@ checksum = "b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52"
 
 [[package]]
 name = "tower-sessions"
-version = "0.1.0"
-source = "git+https://github.com/maxcountryman/tower-sessions?branch=main#0885cc9e992832f6de71c322c33d06be9fc5f0c1"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92fb80fab7ba43e547ef5e051426537d5ada0aacb6fd17132430a34e7ca2164e"
 dependencies = [
  "async-trait",
  "axum-core",

--- a/crates/alexandrie/Cargo.toml
+++ b/crates/alexandrie/Cargo.toml
@@ -70,7 +70,7 @@ flate2 = "1.0.25"
 tar = "0.4.38"
 
 # frontend
-tower-sessions = { git = "https://github.com/maxcountryman/tower-sessions", branch = "main", optional = true }
+tower-sessions = { version = "0.2.0", optional = true }
 handlebars = { version = "4.3.6", features = ["dir_source"], optional = true }
 time = { version = "0.3.20", optional = true }
 num-format = { version = "0.4.4", optional = true }

--- a/crates/alexandrie/Cargo.toml
+++ b/crates/alexandrie/Cargo.toml
@@ -70,7 +70,7 @@ flate2 = "1.0.25"
 tar = "0.4.38"
 
 # frontend
-tower-sessions = { version = "0.2.0", optional = true }
+tower-sessions = { version = "0.2.1", optional = true }
 handlebars = { version = "4.3.6", features = ["dir_source"], optional = true }
 time = { version = "0.3.20", optional = true }
 num-format = { version = "0.4.4", optional = true }

--- a/crates/alexandrie/Cargo.toml
+++ b/crates/alexandrie/Cargo.toml
@@ -29,9 +29,6 @@ axum-extra = "0.7.5"
 # command-line interface
 clap = { version = "4.2.2", features = ["string", "derive"] }
 
-# session handling
-async-session = "3.0.0"
-
 # data types
 url = "2.3.1"
 semver = { version = "1.0.17", features = ["serde"] }
@@ -60,10 +57,9 @@ tantivy = "0.20"
 tantivy-analysis-contrib = { version = "0.9", default-features = false, features = ["commons"] }
 
 # async primitives
-futures-util = "0.3.28"
+futures-util = { version = "0.3.28", features = ["io"] }
 tower = "0.4.13"
 tower-http = { version = "0.4.1", features = ["trace", "fs"] }
-tower-sessions = "0.1.0"
 
 # error handling
 thiserror = { workspace = true }
@@ -74,6 +70,7 @@ flate2 = "1.0.25"
 tar = "0.4.38"
 
 # frontend
+tower-sessions = { git = "https://github.com/maxcountryman/tower-sessions", branch = "main", optional = true }
 handlebars = { version = "4.3.6", features = ["dir_source"], optional = true }
 time = { version = "0.3.20", optional = true }
 num-format = { version = "0.4.4", optional = true }
@@ -91,12 +88,31 @@ tracing-subscriber = { version = "0.3.17", features = ["env-filter"] }
 default = ["frontend", "sqlite"]
 # default = ["frontend", "mysql"]
 # default = ["frontend", "postgres"]
+
+# database vendors
 mysql = ["diesel/mysql", "diesel_migrations/mysql"]
 sqlite = ["diesel/sqlite", "diesel_migrations/sqlite"]
 postgres = ["diesel/postgres", "diesel_migrations/postgres"]
+
+# crate index management strategies
 git2 = ["alexandrie-index/git2"]
+
+# crate stores
 s3 = ["alexandrie-storage/s3"]
-frontend = ["dep:handlebars", "dep:oauth2", "dep:once_cell", "dep:regex", "dep:reqwest", "dep:num-format", "dep:bigdecimal", "dep:time", "diesel/numeric"]
+
+# integrated frontend
+frontend = [
+    "dep:tower-sessions",
+    "dep:handlebars",
+    "dep:oauth2",
+    "dep:once_cell",
+    "dep:regex",
+    "dep:reqwest",
+    "dep:num-format",
+    "dep:bigdecimal",
+    "dep:time",
+    "diesel/numeric",
+]
 
 [build-dependencies]
 built = { version = "0.6.0", features = ["git2", "chrono"] }

--- a/crates/alexandrie/Cargo.toml
+++ b/crates/alexandrie/Cargo.toml
@@ -25,7 +25,6 @@ alexandrie-rendering = { path = "../alexandrie-rendering", version = "0.1.0" }
 tokio = { workspace = true, features = ["rt-multi-thread", "fs", "macros"] }
 axum = { version = "0.6.19", features = ["http2", "headers"] }
 axum-extra = "0.7.5"
-axum-sessions = "0.5.0"
 
 # command-line interface
 clap = { version = "4.2.2", features = ["string", "derive"] }
@@ -64,6 +63,7 @@ tantivy-analysis-contrib = { version = "0.9", default-features = false, features
 futures-util = "0.3.28"
 tower = "0.4.13"
 tower-http = { version = "0.4.1", features = ["trace", "fs"] }
+tower-sessions = "0.1.0"
 
 # error handling
 thiserror = { workspace = true }

--- a/crates/alexandrie/src/frontend/account/github/attach.rs
+++ b/crates/alexandrie/src/frontend/account/github/attach.rs
@@ -5,7 +5,7 @@ use axum::http::StatusCode;
 use axum::response::Redirect;
 use axum_extra::either::Either;
 use axum_extra::response::Html;
-use axum_sessions::extractors::WritableSession;
+use tower_sessions::Session;
 use oauth2::{CsrfToken, Scope};
 
 use crate::config::AppState;
@@ -17,7 +17,7 @@ use crate::utils::auth::frontend::Auth;
 pub(crate) async fn get(
     State(state): State<Arc<AppState>>,
     maybe_author: Option<Auth>,
-    mut session: WritableSession,
+    session: Session,
 ) -> Result<Either<(StatusCode, Html<String>), Redirect>, FrontendError> {
     let Some(Auth(author)) = maybe_author else {
         return Ok(Either::E2(Redirect::to("/account/manage")));

--- a/crates/alexandrie/src/frontend/account/github/attach.rs
+++ b/crates/alexandrie/src/frontend/account/github/attach.rs
@@ -5,8 +5,8 @@ use axum::http::StatusCode;
 use axum::response::Redirect;
 use axum_extra::either::Either;
 use axum_extra::response::Html;
-use tower_sessions::Session;
 use oauth2::{CsrfToken, Scope};
+use tower_sessions::Session;
 
 use crate::config::AppState;
 use crate::error::FrontendError;

--- a/crates/alexandrie/src/frontend/account/github/callback.rs
+++ b/crates/alexandrie/src/frontend/account/github/callback.rs
@@ -267,7 +267,7 @@ pub(crate) async fn get(
 
         //? Set the user's session.
         session.insert("author.id", author_id)?;
-        session.expire_in(expiry);
+        session.set_expiration_time_from_max_age(expiry);
 
         return Ok(Either::E2(Redirect::to("/")));
     });

--- a/crates/alexandrie/src/frontend/account/github/callback.rs
+++ b/crates/alexandrie/src/frontend/account/github/callback.rs
@@ -1,12 +1,11 @@
 use std::sync::Arc;
-use std::time::Duration;
 
 use axum::extract::{Query, State};
 use axum::http::StatusCode;
 use axum::response::Redirect;
 use axum_extra::either::Either;
 use axum_extra::response::Html;
-use axum_sessions::extractors::WritableSession;
+use tower_sessions::Session;
 use diesel::prelude::*;
 use oauth2::reqwest::async_http_client;
 use oauth2::{AuthorizationCode, TokenResponse};
@@ -70,9 +69,9 @@ pub(crate) async fn get(
     State(state): State<Arc<AppState>>,
     Query(query): Query<CallbackQueryData>,
     maybe_author: Option<Auth>,
-    mut session: WritableSession,
+    session: Session,
 ) -> Result<Either<(StatusCode, Html<String>), Redirect>, FrontendError> {
-    let Some(data): Option<GithubLoginState> = session.get(GITHUB_LOGIN_STATE_KEY) else {
+    let Some(data): Option<GithubLoginState> = session.remove(GITHUB_LOGIN_STATE_KEY)? else {
         let rendered = utils::response::error_html(
             state.as_ref(),
             None,
@@ -80,7 +79,6 @@ pub(crate) async fn get(
         )?;
         return Ok(Either::E1((StatusCode::BAD_REQUEST, Html(rendered))));
     };
-    session.remove("login.github");
 
     let current_author = match (data.attach, maybe_author) {
         (true, Some(author)) => Some(author),
@@ -265,7 +263,7 @@ pub(crate) async fn get(
         };
 
         //? Get the maximum duration of the session.
-        let expiry = Duration::from_secs(86_400); // 1 day / 24 hours
+        let expiry = time::Duration::seconds(86_400); // 1 day / 24 hours
 
         //? Set the user's session.
         session.insert("author.id", author_id)?;

--- a/crates/alexandrie/src/frontend/account/github/callback.rs
+++ b/crates/alexandrie/src/frontend/account/github/callback.rs
@@ -5,13 +5,13 @@ use axum::http::StatusCode;
 use axum::response::Redirect;
 use axum_extra::either::Either;
 use axum_extra::response::Html;
-use tower_sessions::Session;
 use diesel::prelude::*;
 use oauth2::reqwest::async_http_client;
 use oauth2::{AuthorizationCode, TokenResponse};
 use ring::digest as hasher;
 use ring::rand::{SecureRandom, SystemRandom};
 use serde::{Deserialize, Serialize};
+use tower_sessions::Session;
 
 use crate::config::frontend::auth::github::GithubAuthOrganizationConfig;
 use crate::config::AppState;

--- a/crates/alexandrie/src/frontend/account/github/mod.rs
+++ b/crates/alexandrie/src/frontend/account/github/mod.rs
@@ -5,7 +5,7 @@ use axum::http::StatusCode;
 use axum::response::Redirect;
 use axum_extra::either::Either;
 use axum_extra::response::Html;
-use axum_sessions::extractors::WritableSession;
+use tower_sessions::Session;
 use oauth2::{CsrfToken, Scope};
 use serde::{Deserialize, Serialize};
 
@@ -33,7 +33,7 @@ struct GithubLoginState {
 pub(crate) async fn get(
     State(state): State<Arc<AppState>>,
     maybe_author: Option<Auth>,
-    mut session: WritableSession,
+    session: Session,
 ) -> Result<Either<(StatusCode, Html<String>), Redirect>, FrontendError> {
     if let Some(Auth(author)) = maybe_author {
         let state = state.as_ref();

--- a/crates/alexandrie/src/frontend/account/github/mod.rs
+++ b/crates/alexandrie/src/frontend/account/github/mod.rs
@@ -5,9 +5,9 @@ use axum::http::StatusCode;
 use axum::response::Redirect;
 use axum_extra::either::Either;
 use axum_extra::response::Html;
-use tower_sessions::Session;
 use oauth2::{CsrfToken, Scope};
 use serde::{Deserialize, Serialize};
+use tower_sessions::Session;
 
 /// Endpoint to attach to an existing Alexandrie account.
 pub mod attach;

--- a/crates/alexandrie/src/frontend/account/gitlab/attach.rs
+++ b/crates/alexandrie/src/frontend/account/gitlab/attach.rs
@@ -5,7 +5,7 @@ use axum::http::StatusCode;
 use axum::response::Redirect;
 use axum_extra::either::Either;
 use axum_extra::response::Html;
-use axum_sessions::extractors::WritableSession;
+use tower_sessions::Session;
 use oauth2::{CsrfToken, Scope};
 
 use crate::config::AppState;
@@ -17,7 +17,7 @@ use crate::utils::auth::frontend::Auth;
 pub(crate) async fn get(
     State(state): State<Arc<AppState>>,
     maybe_author: Option<Auth>,
-    mut session: WritableSession,
+    session: Session,
 ) -> Result<Either<(StatusCode, Html<String>), Redirect>, FrontendError> {
     let Some(Auth(author)) = maybe_author else {
         return Ok(Either::E2(Redirect::to("/account/manage")));

--- a/crates/alexandrie/src/frontend/account/gitlab/attach.rs
+++ b/crates/alexandrie/src/frontend/account/gitlab/attach.rs
@@ -5,8 +5,8 @@ use axum::http::StatusCode;
 use axum::response::Redirect;
 use axum_extra::either::Either;
 use axum_extra::response::Html;
-use tower_sessions::Session;
 use oauth2::{CsrfToken, Scope};
+use tower_sessions::Session;
 
 use crate::config::AppState;
 use crate::error::FrontendError;

--- a/crates/alexandrie/src/frontend/account/gitlab/callback.rs
+++ b/crates/alexandrie/src/frontend/account/gitlab/callback.rs
@@ -234,7 +234,7 @@ pub(crate) async fn get(
 
         //? Set the user's session.
         session.insert("author.id", author_id)?;
-        session.expire_in(expiry);
+        session.set_expiration_time_from_max_age(expiry);
 
         return Ok(Either::E2(Redirect::to("/")));
     });

--- a/crates/alexandrie/src/frontend/account/gitlab/callback.rs
+++ b/crates/alexandrie/src/frontend/account/gitlab/callback.rs
@@ -1,12 +1,10 @@
 use std::sync::Arc;
-use std::time::Duration;
 
 use axum::extract::{Query, State};
 use axum::http::StatusCode;
 use axum::response::Redirect;
 use axum_extra::either::Either;
 use axum_extra::response::Html;
-use axum_sessions::extractors::WritableSession;
 use diesel::prelude::*;
 use oauth2::reqwest::async_http_client;
 use oauth2::{AccessToken, AuthorizationCode, TokenResponse};
@@ -15,6 +13,7 @@ use regex::Regex;
 use ring::digest as hasher;
 use ring::rand::{SecureRandom, SystemRandom};
 use serde::{Deserialize, Serialize};
+use tower_sessions::Session;
 use url::Url;
 
 use crate::config::AppState;
@@ -58,9 +57,9 @@ pub(crate) async fn get(
     State(state): State<Arc<AppState>>,
     Query(query): Query<CallbackQueryData>,
     maybe_author: Option<Auth>,
-    mut session: WritableSession,
+    session: Session,
 ) -> Result<Either<(StatusCode, Html<String>), Redirect>, FrontendError> {
-    let Some(data): Option<GitlabLoginState> = session.get(GITLAB_LOGIN_STATE_KEY) else {
+    let Some(data): Option<GitlabLoginState> = session.remove(GITLAB_LOGIN_STATE_KEY)? else {
         let rendered = utils::response::error_html(
             state.as_ref(),
             None,
@@ -68,7 +67,6 @@ pub(crate) async fn get(
         )?;
         return Ok(Either::E1((StatusCode::BAD_REQUEST, Html(rendered))));
     };
-    session.remove("login.gitlab");
 
     let current_author = match (data.attach, maybe_author) {
         (true, Some(author)) => Some(author),
@@ -232,7 +230,7 @@ pub(crate) async fn get(
         };
 
         //? Get the maximum duration of the session.
-        let expiry = Duration::from_secs(86_400); // 1 day / 24 hours
+        let expiry = time::Duration::seconds(86_400); // 1 day / 24 hours
 
         //? Set the user's session.
         session.insert("author.id", author_id)?;

--- a/crates/alexandrie/src/frontend/account/gitlab/mod.rs
+++ b/crates/alexandrie/src/frontend/account/gitlab/mod.rs
@@ -5,9 +5,9 @@ use axum::http::StatusCode;
 use axum::response::Redirect;
 use axum_extra::either::Either;
 use axum_extra::response::Html;
-use tower_sessions::Session;
 use oauth2::{CsrfToken, Scope};
 use serde::{Deserialize, Serialize};
+use tower_sessions::Session;
 
 /// Endpoint to attach to an existing Alexandrie account.
 pub mod attach;

--- a/crates/alexandrie/src/frontend/account/gitlab/mod.rs
+++ b/crates/alexandrie/src/frontend/account/gitlab/mod.rs
@@ -5,7 +5,7 @@ use axum::http::StatusCode;
 use axum::response::Redirect;
 use axum_extra::either::Either;
 use axum_extra::response::Html;
-use axum_sessions::extractors::WritableSession;
+use tower_sessions::Session;
 use oauth2::{CsrfToken, Scope};
 use serde::{Deserialize, Serialize};
 
@@ -33,7 +33,7 @@ struct GitlabLoginState {
 pub(crate) async fn get(
     State(state): State<Arc<AppState>>,
     maybe_author: Option<Auth>,
-    mut session: WritableSession,
+    session: Session,
 ) -> Result<Either<(StatusCode, Html<String>), Redirect>, FrontendError> {
     if let Some(Auth(author)) = maybe_author {
         let state = state.as_ref();

--- a/crates/alexandrie/src/frontend/account/login.rs
+++ b/crates/alexandrie/src/frontend/account/login.rs
@@ -7,11 +7,11 @@ use axum::response::Redirect;
 use axum::Form;
 use axum_extra::either::Either;
 use axum_extra::response::Html;
-use tower_sessions::Session;
 use diesel::prelude::*;
 use json::json;
 use ring::pbkdf2;
 use serde::{Deserialize, Serialize};
+use tower_sessions::Session;
 
 use crate::config::AppState;
 use crate::db::schema::*;

--- a/crates/alexandrie/src/frontend/account/login.rs
+++ b/crates/alexandrie/src/frontend/account/login.rs
@@ -154,7 +154,7 @@ pub(crate) async fn post(
 
         //? Set the user's session.
         session.insert("author.id", author_id)?;
-        session.expire_in(expiry);
+        session.set_expiration_time_from_max_age(expiry);
 
         Ok(Either::E2(Redirect::to("/")))
     });

--- a/crates/alexandrie/src/frontend/account/logout.rs
+++ b/crates/alexandrie/src/frontend/account/logout.rs
@@ -1,7 +1,7 @@
 use axum::response::Redirect;
-use axum_sessions::extractors::WritableSession;
+use tower_sessions::Session;
 
-pub(crate) async fn get(mut session: WritableSession) -> Redirect {
-    session.remove("author.id");
+pub(crate) async fn get(mut session: Session) -> Redirect {
+    session.remove_value("author.id");
     Redirect::to("/")
 }

--- a/crates/alexandrie/src/frontend/account/logout.rs
+++ b/crates/alexandrie/src/frontend/account/logout.rs
@@ -1,7 +1,7 @@
 use axum::response::Redirect;
 use tower_sessions::Session;
 
-pub(crate) async fn get(mut session: Session) -> Redirect {
+pub(crate) async fn get(session: Session) -> Redirect {
     session.remove_value("author.id");
     Redirect::to("/")
 }

--- a/crates/alexandrie/src/frontend/account/manage/mod.rs
+++ b/crates/alexandrie/src/frontend/account/manage/mod.rs
@@ -3,11 +3,11 @@ use std::sync::Arc;
 use axum::extract::State;
 use axum::http::StatusCode;
 use axum_extra::response::Html;
-use tower_sessions::Session;
 use diesel::dsl as sql;
 use diesel::prelude::*;
 use json::json;
 use serde::{Deserialize, Serialize};
+use tower_sessions::Session;
 
 /// Password management routes (eg. "/account/manage/password").
 pub mod passwd;

--- a/crates/alexandrie/src/frontend/account/manage/mod.rs
+++ b/crates/alexandrie/src/frontend/account/manage/mod.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use axum::extract::State;
 use axum::http::StatusCode;
 use axum_extra::response::Html;
-use axum_sessions::extractors::WritableSession;
+use tower_sessions::Session;
 use diesel::dsl as sql;
 use diesel::prelude::*;
 use json::json;
@@ -43,7 +43,7 @@ enum ManageFlashMessage {
 pub(crate) async fn get(
     State(state): State<Arc<AppState>>,
     maybe_author: Option<Auth>,
-    mut session: WritableSession,
+    session: Session,
 ) -> Result<(StatusCode, Html<String>), FrontendError> {
     let Some(Auth(author)) = maybe_author else {
         let state = state.as_ref();
@@ -71,10 +71,7 @@ pub(crate) async fn get(
             .filter(author_tokens::author_id.eq(author.id))
             .load::<AuthorToken>(conn)?;
 
-        let flash_message: Option<ManageFlashMessage> = session.get(ACCOUNT_MANAGE_FLASH);
-        if flash_message.is_some() {
-            session.remove(ACCOUNT_MANAGE_FLASH);
-        }
+        let flash_message: Option<ManageFlashMessage> = session.remove(ACCOUNT_MANAGE_FLASH)?;
 
         let engine = &state.frontend.handlebars;
         let context = json!({

--- a/crates/alexandrie/src/frontend/account/manage/passwd.rs
+++ b/crates/alexandrie/src/frontend/account/manage/passwd.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 use axum::extract::State;
 use axum::response::Redirect;
 use axum::Form;
-use axum_sessions::extractors::WritableSession;
+use tower_sessions::Session;
 use diesel::prelude::*;
 use ring::digest as hasher;
 use ring::pbkdf2;
@@ -28,7 +28,7 @@ pub(crate) struct ChangePasswordForm {
 pub(crate) async fn post(
     State(state): State<Arc<AppState>>,
     maybe_author: Option<Auth>,
-    mut session: WritableSession,
+    session: Session,
     Form(form): Form<ChangePasswordForm>,
 ) -> Result<Redirect, FrontendError> {
     let Some(Auth(author)) = maybe_author else {

--- a/crates/alexandrie/src/frontend/account/manage/passwd.rs
+++ b/crates/alexandrie/src/frontend/account/manage/passwd.rs
@@ -4,11 +4,11 @@ use std::sync::Arc;
 use axum::extract::State;
 use axum::response::Redirect;
 use axum::Form;
-use tower_sessions::Session;
 use diesel::prelude::*;
 use ring::digest as hasher;
 use ring::pbkdf2;
 use serde::{Deserialize, Serialize};
+use tower_sessions::Session;
 
 use crate::config::AppState;
 use crate::db::schema::*;

--- a/crates/alexandrie/src/frontend/account/manage/tokens/mod.rs
+++ b/crates/alexandrie/src/frontend/account/manage/tokens/mod.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use axum::extract::State;
 use axum::response::Redirect;
 use axum::Form;
-use axum_sessions::extractors::WritableSession;
+use tower_sessions::Session;
 use diesel::prelude::*;
 use serde::{Deserialize, Serialize};
 
@@ -28,7 +28,7 @@ pub(crate) struct CreateTokenForm {
 pub(crate) async fn post(
     State(state): State<Arc<AppState>>,
     maybe_author: Option<Auth>,
-    mut session: WritableSession,
+    session: Session,
     Form(form): Form<CreateTokenForm>,
 ) -> Result<Redirect, FrontendError> {
     let Some(Auth(author)) = maybe_author else {

--- a/crates/alexandrie/src/frontend/account/manage/tokens/mod.rs
+++ b/crates/alexandrie/src/frontend/account/manage/tokens/mod.rs
@@ -3,9 +3,9 @@ use std::sync::Arc;
 use axum::extract::State;
 use axum::response::Redirect;
 use axum::Form;
-use tower_sessions::Session;
 use diesel::prelude::*;
 use serde::{Deserialize, Serialize};
+use tower_sessions::Session;
 
 /// Token revocation routes (eg. "/account/manage/tokens/5/revoke").
 pub mod revoke;

--- a/crates/alexandrie/src/frontend/account/manage/tokens/revoke.rs
+++ b/crates/alexandrie/src/frontend/account/manage/tokens/revoke.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use axum::extract::{Path, State};
 use axum::response::Redirect;
-use axum_sessions::extractors::WritableSession;
+use tower_sessions::Session;
 use diesel::prelude::*;
 
 use crate::config::AppState;
@@ -16,7 +16,7 @@ pub(crate) async fn get(
     State(state): State<Arc<AppState>>,
     Path(id): Path<i64>,
     maybe_author: Option<Auth>,
-    mut session: WritableSession,
+    session: Session,
 ) -> Result<Redirect, FrontendError> {
     let Some(Auth(author)) = maybe_author else {
         return Ok(Redirect::to("/account/manage"));

--- a/crates/alexandrie/src/frontend/account/manage/tokens/revoke.rs
+++ b/crates/alexandrie/src/frontend/account/manage/tokens/revoke.rs
@@ -2,8 +2,8 @@ use std::sync::Arc;
 
 use axum::extract::{Path, State};
 use axum::response::Redirect;
-use tower_sessions::Session;
 use diesel::prelude::*;
+use tower_sessions::Session;
 
 use crate::config::AppState;
 use crate::db::schema::*;

--- a/crates/alexandrie/src/frontend/account/register.rs
+++ b/crates/alexandrie/src/frontend/account/register.rs
@@ -46,7 +46,7 @@ pub(crate) struct RegisterForm {
 pub(crate) async fn get(
     State(state): State<Arc<AppState>>,
     maybe_author: Option<Auth>,
-    mut session: Session,
+    session: Session,
 ) -> Result<(StatusCode, Html<String>), FrontendError> {
     if let Some(Auth(author)) = maybe_author {
         return common::already_logged_in(state.as_ref(), author);
@@ -209,7 +209,7 @@ pub(crate) async fn post(
 
         //? Set the user's session.
         session.insert("author.id", author_id)?;
-        session.expire_in(expiry);
+        session.set_expiration_time_from_max_age(expiry);
 
         Ok(Either::E2(Redirect::to("/")))
     });

--- a/crates/alexandrie/src/utils/mod.rs
+++ b/crates/alexandrie/src/utils/mod.rs
@@ -6,7 +6,9 @@ pub mod build;
 pub mod checks;
 /// Various utilities to assist building HTTP responses.
 pub mod response;
+
 /// Various session-related utilities.
+#[cfg(feature = "frontend")]
 pub mod sessions;
 
 /// Transforms a crate name to its canonical form.

--- a/crates/alexandrie/src/utils/sessions.rs
+++ b/crates/alexandrie/src/utils/sessions.rs
@@ -1,24 +1,53 @@
 use std::fmt;
 
-use async_session::{Session, SessionStore};
+use time::format_description;
+// use async_session::{Session, SessionStore};
 use axum::async_trait;
 use diesel::dsl;
 use diesel::prelude::*;
+use thiserror::Error;
+use time::macros::format_description;
+use tower_sessions::session::{Session, SessionId, SessionRecord};
+use tower_sessions::session_store::SessionStore;
 
-use crate::db::models::Session as SessionRecord;
+use crate::db::models::Session as SessionEntry;
+use crate::db::schema::*;
 use crate::db::Database;
-use crate::db::{schema::*, DATETIME_FORMAT};
+
+/// The date-time format used in the database.
+pub static SESSION_DATE_FORMAT: &[format_description::FormatItem] =
+    format_description!("[year]-[month]-[day] [hour]:[minute]:[second]");
+
+/// The error type when interacting with the session store.
+#[derive(Debug, Error)]
+pub enum SqlStoreError {
+    /// Session error.
+    #[error("session error: {0}")]
+    Session(#[from] tower_sessions::session::SessionError),
+    /// JSON (de)serialization error.
+    #[error("JSON error: {0}")]
+    Json(#[from] json::Error),
+    /// Time formatting error.
+    #[error("time formatting error: {0}")]
+    TimeFormat(#[from] time::error::Format),
+    /// Time parsing error.
+    #[error("time parsing error: {0}")]
+    TimeParse(#[from] time::error::Parse),
+    /// Diesel query error.
+    #[error("diesel error: {0}")]
+    Diesel(#[from] diesel::result::Error),
+}
 
 /// A SQL-based session store.
 #[derive(Clone)]
 pub struct SqlStore {
-    db: Database,
+    database: Database,
 }
 
 impl SqlStore {
     /// Create a new `SqlStore`.
-    pub fn new(db: Database) -> Self {
-        Self { db }
+    pub fn new(database: Database) -> Self {
+        Self { database }
     }
 }
 
@@ -30,45 +59,34 @@ impl fmt::Debug for SqlStore {
 
 #[async_trait]
 impl SessionStore for SqlStore {
-    async fn load_session(&self, cookie_value: String) -> async_session::Result<Option<Session>> {
-        let id = Session::id_from_cookie_value(&cookie_value)?;
-        // eprintln!("searching session: {:?}", id);
+    type Error = SqlStoreError;
 
-        let data: Option<String> = self
-            .db
-            .run(|conn| {
-                sessions::table
-                    .find(id)
-                    .select(sessions::data)
-                    .first(conn)
-                    .optional()
-            })
-            .await?;
-
-        let session: Option<Session> = data.map(|data| json::from_str(&data)).transpose()?;
-        Ok(session)
-    }
-
-    async fn store_session(&self, session: Session) -> async_session::Result<Option<String>> {
+    async fn save(&self, session: &SessionRecord) -> Result<(), Self::Error> {
         let id = session.id().to_string();
-        let data = json::to_string(&session)?;
-        let author_id: Option<i64> = session.get("author.id");
+        let data = session.data();
+        let author_id: Option<i64> = data
+            .get("author.id")
+            .cloned()
+            .map(json::from_value)
+            .transpose()?;
+
+        let data = json::to_string(&data)?;
+
         let expiry = session
-            .expiry()
-            .map(|it| it.format(DATETIME_FORMAT).to_string())
+            .expiration_time()
+            .map(|it| it.format(SESSION_DATE_FORMAT))
+            .transpose()?
             .unwrap_or_default();
 
-        let record = SessionRecord {
+        let record = SessionEntry {
             id,
             author_id,
             expiry,
             data,
         };
 
-        // eprintln!("storing session: {:?}", record);
-
-        self.db
-            .transaction(move |conn| -> async_session::Result<_> {
+        self.database
+            .transaction(move |conn| -> Result<(), Self::Error> {
                 let exists: bool =
                     dsl::select(dsl::exists(sessions::table.find(&record.id))).get_result(conn)?;
 
@@ -86,22 +104,41 @@ impl SessionStore for SqlStore {
             })
             .await?;
 
-        Ok(session.into_cookie_value())
-    }
-
-    async fn destroy_session(&self, session: Session) -> async_session::Result {
-        self.db
-            .run(move |conn| diesel::delete(sessions::table.find(session.id())).execute(conn))
-            .await?;
-
         Ok(())
     }
 
-    async fn clear_store(&self) -> async_session::Result {
-        self.db
-            .run(move |conn| diesel::delete(sessions::table).execute(conn))
+    async fn load(&self, session_id: &SessionId) -> Result<Option<Session>, Self::Error> {
+        let id = session_id.to_string();
+        let now = time::OffsetDateTime::now_utc().format(SESSION_DATE_FORMAT)?;
+
+        let maybe_entry: Option<SessionEntry> = self
+            .database
+            .run(|conn| {
+                sessions::table
+                    .find(id)
+                    .filter(sessions::expiry.gt(now))
+                    .first(conn)
+                    .optional()
+            })
             .await?;
 
+        let Some(entry) = maybe_entry else {
+            return Ok(None);
+        };
+
+        let session_id = SessionId::try_from(entry.id)?;
+        let expiration_time = time::OffsetDateTime::parse(&entry.expiry, SESSION_DATE_FORMAT)?;
+        let data = json::from_str(&entry.data)?;
+        let session_record = SessionRecord::new(session_id, Some(expiration_time), data);
+
+        Ok(Some(session_record.into()))
+    }
+
+    async fn delete(&self, session_id: &SessionId) -> Result<(), Self::Error> {
+        let id = session_id.to_string();
+        self.database
+            .run(move |conn| diesel::delete(sessions::table.find(id)).execute(conn))
+            .await?;
         Ok(())
     }
 }

--- a/crates/alexandrie/src/utils/sessions.rs
+++ b/crates/alexandrie/src/utils/sessions.rs
@@ -127,7 +127,8 @@ impl SessionStore for SqlStore {
         };
 
         let session_id = SessionId::try_from(entry.id)?;
-        let expiration_time = time::OffsetDateTime::parse(&entry.expiry, SESSION_DATE_FORMAT)?;
+        let expiration_time =
+            time::PrimitiveDateTime::parse(&entry.expiry, SESSION_DATE_FORMAT)?.assume_utc();
         let data = json::from_str(&entry.data)?;
         let session_record = SessionRecord::new(session_id, Some(expiration_time), data);
 


### PR DESCRIPTION
As @maxcountryman, the author of the `axum-sessions` crate, has kindly notified us in **#174**, `axum-sessions` has been hitting some problems due to its dependence on `async-sessions`, and a successor crate called `tower-sessions` has been released, which is free of this dependency and less limited in its API design.  

This PR, therefore, refactors Alexandrie to use this new `tower-sessions` crate instead of `axum-sessions`.

**Closes #174.**